### PR TITLE
Add watch command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ We make certain sections of the site dynamic by injecting small react components
 Our goal is to keep the pages fast, publish the info that people read first statically in html so it renders ~immediately and then load any dynamic content in small components on the page afterwards.
 
 
-## First make sure you're using the old node 16
+## first make sure you're using the old node 16
 - Can use a package manager like [nvm](https://github.com/nvm-sh/nvm)
 - Then: `nvm use 16`
 
@@ -30,7 +30,8 @@ For development:
   - then rebuild the js with `yarn build-js`
 
 - Build the react components:
-  - `yarn build-js` will build the react components and move the js files into the hugo directories
+  - `yarn build-js` will build the react components and move the js files into the hugo directories 1x
+  - For development, run `yarn build-js-watch` to rebuild on every change
 - Fetch the current 5 Calls content
   - `yarn build-content` will fetch the latest topics and build hugo content files in the right place
 - Build and deploy hugo

--- a/react/package.json
+++ b/react/package.json
@@ -28,6 +28,7 @@
     "build-content": "yarn run ts-node -O '{\"module\": \"commonjs\"}' scripts/build-content.ts",
     "build-archives": "yarn run ts-node -O '{\"module\": \"commonjs\"}' scripts/build-archives.ts",
     "build-js": "yarn build && yarn move",
+    "build-js-watch": "node ./scripts/watch-changes.js",
     "move": "node ./scripts/move-built.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/react/scripts/watch-changes.js
+++ b/react/scripts/watch-changes.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+const path = require('path');
+
+const directoryPath = path.join(__dirname, '..', 'src');
+const command = 'npm run build-js';
+
+fs.watch(directoryPath, { recursive: true }, (eventType, filename) => {
+  if (filename) {
+    console.log(`File ${filename} has been changed`);
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error executing command: ${error}`);
+        return;
+      }
+      console.log(`stdout: ${stdout}`);
+      console.error(`stderr: ${stderr}`);
+    });
+  }
+});
+
+console.log('Watching for changes in the src directory...');


### PR DESCRIPTION
Starting to work on #17 and I was finding it laborious to rerun the build js command every time I made a change. This script  (`yarn run build-js-watch`) should just rerun it for you when you save a file.

I haven't tested it super extensively, though it is working for my use case of editing react components and seeing the changes immediately.

## Question
I'm still trying to understand how hugo + react are working together, normally i would use the `yarn start` command but that doesn't seem to work since it doesn't integrate with the hugo server -- can you confirm the approach in this pr is the best way to go about this?