### PR TITLE
[design]Use system fonts for more native mobile experience

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -3,6 +3,7 @@
 :root {
   // Typography
   --base-font-size: 16;
+  --base-font-family: system-ui, -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto, noto, helvetica, arial, sans-serif; 
   --leading: 1.4;
   --leading-rem: calc(var(--leading) * 1rem);
   --paragraph-break: calc(var(--leading) * 0.75rem);
@@ -42,13 +43,14 @@
   }
 }
 
+
 //  Basic layout
 
 html,
 input,
 select,
 button {
-  font-family: "Roboto", sans-serif;
+  font-family: var(--base-font-family);
   color: var(--c-base);
 }
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -76,10 +76,7 @@
     <!-- prettier-ignore -->
     {{ hugo.Generator }} {{ $style := resources.Get "sass/main.scss" | css.Sass | resources.Minify }}
     <link rel="stylesheet" href="{{ $style.Permalink }}" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap"
-      rel="stylesheet"
-    />
+ 
 
     {{ $js := resources.Match "js/*.js" }} {{ range $js }}
     <script type="module" src="{{ .RelPermalink }}" defer></script>


### PR DESCRIPTION
After talking about how most usage is on mobile this morning, i was spending more time on the mobile website  on my phone looking around. 

I have an iphone and I found the Roboto font jarring -- that's the android font! This pr simply updates the font to make sure that the right default font for each OS is shown for each user. So on my iphone i will see [San Francisco](https://developer.apple.com/fonts/), while android users will see Roboto still.

There are also potential performance benefits to this change. [More info about system fonts here.](https://css-tricks.com/snippets/css/system-font-stack/)

If during the redesign we choose to add an additional accent font for headers, we can layer that easily on top of this pr.