### PR TITLE
[Bugfix] Force hugo to load sourcemap files

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -80,7 +80,14 @@
     {{ $js := resources.Match "js/*.js" }} {{ range $js }}
     <script type="module" src="{{ .RelPermalink }}" defer></script>
     {{ end }}
-    
+
+    {{ if hugo.IsProduction }}
+      {{ $jsMap := resources.Match "js/*.js.map" }}
+        {{ range $jsMap }}
+        {{ .Publish }}
+      {{ end }}
+    {{ end }}
+
     <script src="https://secure.actblue.com/cf/assets/actblue.js" async></script>
   
     <script defer data-domain="5calls.org" src="https://plausible.io/js/script.tagged-events.js"></script>


### PR DESCRIPTION
https://github.com/5calls/static/issues/43

Post https://github.com/5calls/static/pull/36, I knew we were still generating sourcemaps so I was surprised by this issue but I was easily able to confirm the problem on the prod version of the website. It seems like hugo [does not load files in the assets dir unless forced to do so](https://aamnah.com/notes/hugo/hugo-assets-directory/), which is why the sourcemap was 404ing. It seems like there were 2 solutions -- move the sourcemap to the static directory, but I wasn't sure how to update the paths properly; or do what I am doing based on [this thread here.](https://discourse.gohugo.io/t/can-i-copy-file-from-assets-to-static-on-conditional-build/40734).

To be honest I'm not sure how I broke it, since presumably this would have been an issue even before the parcel refactor...