### PR TITLE
Fix remaining eslint errors, and run lint on ci from github action going forward

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Change to react directory
-        run: cd react
 
       - name: Install dependencies
         run: yarn install
+        working-directory: react
 
       - name: Run linter
         run: npm run lint
+        working-directory: react
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: Lint on Pull Request
+
+on:
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.jsx'
+      - '**/*.tsx'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linter
+        run: npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Change to react directory
+        run: cd react
+
       - name: Install dependencies
-        run: npm install
+        run: yarn install
 
       - name: Run linter
         run: npm run lint

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-./react/node_modules

--- a/react/eslint.config.mjs
+++ b/react/eslint.config.mjs
@@ -1,14 +1,24 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
-
+import globals from 'globals'
+import pluginJs from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import pluginReact from 'eslint-plugin-react'
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {languageOptions: { globals: globals.browser }},
+  { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
+  { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'react/display-name': 'off',
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
+]

--- a/react/src/common/models/actblue.ts
+++ b/react/src/common/models/actblue.ts
@@ -12,7 +12,7 @@ export interface RequestActBlueContributionConfig {
   amounts?: string | number[]; // new option coming, could be string of comma seperated amounts in cents, or an array of cents in integers
   donor?: ActBlueDonor; // pre-set information about the donor
   embedId?: string; // specify your own id, which is echoed back in the `onContribute` events
-  refcodes?: {}; // an object of {refcodeBlah: 'blah'}
+  refcodes?: Record<string, string>; // an object of {refcodeBlah: 'blah'}
   styleSheetHref?: string; // url to a stylesheet which will be injected in the form
 }
 
@@ -30,5 +30,5 @@ export interface ActBlueContribution {
   name: string; // name of the embed form created in actblue
   order_number: string; // order number, referencable in the actblue management interface
   recurring: boolean; // if the contribution was a recurring one
-  refcodes?: {}; // any refcodes added with the contribution
+  refcodes?: Record<string, string>; // any refcodes added with the contribution
 }

--- a/react/src/components/APIForm.tsx
+++ b/react/src/components/APIForm.tsx
@@ -2,14 +2,13 @@ import React from "react";
 import { postAPIEmail } from "../utils/api";
 import { AxiosError } from "axios";
 
-interface Props {}
 interface State {
   emailSent: boolean;
   email: string;
   errorText: string;
 }
 
-class APIForm extends React.Component<Props, State> {
+class APIForm extends React.Component<null, State> {
   state = {
     emailSent: false,
     email: '',
@@ -20,7 +19,7 @@ class APIForm extends React.Component<Props, State> {
     e.preventDefault();
 
     postAPIEmail(this.state.email)
-    .then((d) => {
+    .then(() => {
       this.setState({emailSent: true})
     })
     .catch((error) => {

--- a/react/src/components/ActiveContact.tsx
+++ b/react/src/components/ActiveContact.tsx
@@ -7,9 +7,8 @@ import LocalNumbers from "./LocalNumbers";
 interface Props {
   contact: Contact;
 }
-interface State {}
 
-class ActiveContact extends React.Component<Props, State> {
+class ActiveContact extends React.Component<Props> {
   render() {
     let photoURL = "/images/no-rep.png";
     if (this.props.contact.photoURL && this.props.contact.photoURL !== "") {

--- a/react/src/components/CallCount.tsx
+++ b/react/src/components/CallCount.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { getCountData } from "../utils/api";
 
-interface Props {}
 interface State {
   callCount: number;
 }
 
-class CallCount extends React.Component<Props, State> {
+class CallCount extends React.Component<null, State> {
   state = {
     callCount: 0,
   };
@@ -19,9 +18,9 @@ class CallCount extends React.Component<Props, State> {
 
   render(): React.ReactNode {
     if (this.state.callCount > 0) {
-      return <span>We've made {this.state.callCount.toLocaleString()} calls so far. Join&nbsp;us.</span>
+      return <span>We&rsquo;ve made {this.state.callCount.toLocaleString()} calls so far. Join&nbsp;us.</span>
     } else {
-      return <span>We've made more than 7 million calls so far. Join&nbsp;us.</span>
+      return <span>We&rsquo;ve made more than 7 million calls so far. Join&nbsp;us.</span>
     }
   }
 }

--- a/react/src/components/GroupCallCount.tsx
+++ b/react/src/components/GroupCallCount.tsx
@@ -28,7 +28,7 @@ class GroupCallCount extends React.Component<Props, State> {
           isLoading: false 
         });
       })
-      .catch((error) => {
+      .catch(() => {
         this.setState({ 
           error: "Failed to load call counts",
           isLoading: false 

--- a/react/src/components/LocalNumbers.tsx
+++ b/react/src/components/LocalNumbers.tsx
@@ -7,9 +7,8 @@ interface Props {
   contact: Contact;
 }
 
-export interface State {}
 
-export class LocalNumbers extends React.Component<Props, State> {
+export class LocalNumbers extends React.Component<Props> {
   render() {
     if (this.props.contact.field_offices == null || this.props.contact.field_offices.length === 0) {
       return <span />;

--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -15,14 +15,13 @@ enum ComponentLocationState {
   EnterManually,
 }
 
-interface Props {}
 interface State {
   componentLocationState: ComponentLocationState;
   manualAddress: string | undefined;
   locationError: string | undefined;
 }
 
-class Location extends React.Component<Props & WithLocationProps & WithCompletedProps, State> {
+class Location extends React.Component<WithLocationProps & WithCompletedProps, State> {
   _defaultManualAddress: string | undefined = undefined;
   _defaultLocationError: string | undefined = undefined;
 
@@ -141,7 +140,7 @@ class Location extends React.Component<Props & WithLocationProps & WithCompleted
         // // this.props.setLocation(loc);
         // this.setState({ componentLocationState: ComponentLocationState.HasLocation });
       })
-      .catch((err) => {
+      .catch(() => {
         // nbd, go to manual entry
         this.setState({ componentLocationState: ComponentLocationState.EnterManually });
       });
@@ -196,7 +195,7 @@ class Location extends React.Component<Props & WithLocationProps & WithCompleted
               <button className="button button-small button-red">Go</button>
             </form>
             {this.state.locationError && (
-              <span className="location-error">Couldn't find that location, please try again</span>
+              <span className="location-error">Couldn&rsquo;t find that location, please try again</span>
             )}
           </div>
         );

--- a/react/src/components/Outcomes.tsx
+++ b/react/src/components/Outcomes.tsx
@@ -1,12 +1,11 @@
 import React, { createRef } from "react";
 
-interface Props {}
 interface State {
   outcomes: string[];
   showReps: boolean;
 }
 
-class Outcomes extends React.Component<Props, State> {
+class Outcomes extends React.Component<null, State> {
   _defaultOutcomes: string[] = [];
   state = {
     outcomes: this._defaultOutcomes,
@@ -21,7 +20,7 @@ class Outcomes extends React.Component<Props, State> {
       this.setState({ outcomes });
     }
 
-    document.addEventListener("loadedReps", (e) => {
+    document.addEventListener("loadedReps", () => {
       this.setState({ showReps: true });
     });
   }

--- a/react/src/components/PhoneSubscribe.tsx
+++ b/react/src/components/PhoneSubscribe.tsx
@@ -2,14 +2,13 @@ import React from "react";
 import OneSignal from "react-onesignal";
 import Input, { isValidPhoneNumber } from "react-phone-number-input/input";
 
-interface Props {}
 interface State {
   phone: string;
   validPhone: boolean;
   submitted: boolean;
 }
 
-class PhoneSubscribe extends React.Component<Props, State> {
+class PhoneSubscribe extends React.Component<null, State> {
   state = {
     phone: '',
     validPhone: false,

--- a/react/src/components/Script.tsx
+++ b/react/src/components/Script.tsx
@@ -5,7 +5,6 @@ import { Contact } from "../common/models/contact";
 import { LocationState, WithLocationProps } from "../state/locationState";
 import { withLocation } from "../state/stateProvider";
 
-interface Props { }
 interface State {
   scriptMarkdown: string;
   currentContact?: Contact;
@@ -15,7 +14,7 @@ interface State {
 const titleReg = /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]/gi;
 const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
 
-class Script extends React.Component<Props & WithLocationProps, State> {
+class Script extends React.Component<WithLocationProps, State> {
   state: State = { scriptMarkdown: "" };
   scriptRef = createRef<HTMLSpanElement>();
 

--- a/react/src/components/Share.tsx
+++ b/react/src/components/Share.tsx
@@ -1,14 +1,13 @@
 import React, { createRef } from "react";
 import { APP_URL } from "../common/constants";
 
-interface Props {}
 interface State {
   issueSlug: string;
   issueId: string;
   issueTitle: string;
 }
 
-class Share extends React.Component<Props, State> {
+class Share extends React.Component<null, State> {
   private componentRef = createRef<HTMLDivElement>();
 
   state = {

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -70,9 +70,7 @@ firebase.auth().onAuthStateChanged((user) => {
     firebase
       .auth()
       .signInAnonymously()
-      .then((user) => {
-        // ok user signed in
-      })
+
       .catch((error) => {
         console.log("error signing in user", error);
       });

--- a/react/src/state/stateProvider.tsx
+++ b/react/src/state/stateProvider.tsx
@@ -16,8 +16,6 @@ interface State {
 
 export default class StateProvider extends React.Component<Props, State> {
 
-  displayName = "StateProvider";
-
   state: State = {
     locationState: undefined,
     savedStateRestored: false,

--- a/react/src/state/stateProvider.tsx
+++ b/react/src/state/stateProvider.tsx
@@ -4,7 +4,10 @@ import { LocationState, LocationContext, WithLocationProps } from "./locationSta
 import Storage from "../utils/storage";
 import { CompletedContext, CompletedState, CompletionMap, WithCompletedProps } from "./completedState";
 
-interface Props {}
+interface Props {
+  children: React.ReactNode
+}
+
 interface State {
   locationState?: LocationState;
   completedState?: CompletedState;
@@ -12,6 +15,9 @@ interface State {
 }
 
 export default class StateProvider extends React.Component<Props, State> {
+
+  displayName = "StateProvider";
+
   state: State = {
     locationState: undefined,
     savedStateRestored: false,
@@ -69,7 +75,7 @@ export default class StateProvider extends React.Component<Props, State> {
     });
   }
 
-  render(): JSX.Element {
+  render(): React.ReactNode {
     // simple version of the redux-persist gate where nothing is rendered until the persisted
     // data is loaded for the first time
     if (!this.state.savedStateRestored) {

--- a/react/src/utils/api.ts
+++ b/react/src/utils/api.ts
@@ -116,7 +116,7 @@ export const postOutcomeData = async (data: OutcomeData) => {
     .post(`${Constants.REPORT_API_URL}`, postData, {
       headers,
     })
-    .then((response) => {
+    .then(() => {
       return Promise.resolve(null);
     })
     .catch((e) => Promise.reject(e));
@@ -167,7 +167,7 @@ export const postPhoneRemind = (phone: string): Promise<boolean> => {
   });
   return axios
     .post(Constants.REMINDER_API_URL, postData)
-    .then((response) => Promise.resolve(true))
+    .then(() => Promise.resolve(true))
     .catch((e) => Promise.reject(e));
 };
 
@@ -182,7 +182,7 @@ export const postEmail = (email: string, sub: boolean, idToken: string): Promise
     .post(Constants.PROFILE_API_URL, postData, {
       headers: { Authorization: "Bearer " + idToken },
     })
-    .then((response) => Promise.resolve(true))
+    .then(() => Promise.resolve(true))
     .catch((e) => Promise.reject(e));
 };
 
@@ -192,6 +192,6 @@ export const postAPIEmail = (email: string): Promise<boolean> => {
   });
   return axios
     .post(Constants.API_TOKEN_URL, postData)
-    .then((response) => Promise.resolve(true))
+    .then(() => Promise.resolve(true))
     .catch((e) => Promise.reject(e));
 };


### PR DESCRIPTION
## Motivation

Linting new code with eslint is good practice and helps keep the codebase tidy, especially if we want to encourage other people to possibly contribute.

I did my best fixing the last 20 or so eslint errors. I had run `eslint --fix` in the previous react pr to clean up the easy stuff.

I did disable the `noImplicitAny` rule to help me out, we could always revert in a follow up. My main goal here is to run the linter on every PR, but the failing lint job does not block merging so  no additional friction should be added, just helpful information.

## QA

- Verify the new lint command at the bottom of this pr completed successfully.
- Verify there are no changes to the app (the only thing that might have affected what people see is moving `'` to the html entity`&rsquo;` in several places, but that should be ok, e.g. here: )
![Screenshot 2025-03-21 at 9 20 45 AM](https://github.com/user-attachments/assets/4deac7d8-a92c-4cc8-b0ac-269a9af2b291)
