### PR TITLE
Add back success state for finished calls

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -35,6 +35,7 @@
   --c-momentum-rgb: 3, 182, 85;
   --c-unsorted: var(--c-dark);
   --c-unsorted-rgb: var(--c-dark-rgb);
+  --c-success: rgb(95 190 145);
 
   // Layout
   --g-gap: 2rem;

--- a/assets/sass/components/_issue-sidebar.scss
+++ b/assets/sass/components/_issue-sidebar.scss
@@ -189,15 +189,6 @@
   display: block;
   margin-right: var(--i-bar-check-margin);
   position: relative;
-  transition: transform 0.15s ease-out;
-
-  .i-bar-item:hover & {
-    transform: scale(1.12);
-  }
-
-  .i-bar-item:active & {
-    transform: scale(1.05);
-  }
 
   i {
     color: #fff;
@@ -282,29 +273,34 @@
 
   .i-bar-item.is-active {
     background: rgba(var(--c-#{$status}-rgb), 0.05);
+    strong {
+      font-weight: bold;
+      color: var(--c-dark)
+    }
+    
   }
 
-  .i-bar-item.is-#{$status} {
-    --check-color: rgba(var(--c-#{$status}-rgb), 0.8);
-
-    &:hover,
-    &:focus {
-      background: rgba(var(--c-#{$status}-rgb), 0.05);
-    }
-
-    .i-bar-check-initial {
-      background: var(--check-color);
-    }
-
-    .i-bar-check-completed,
-    .i-bar-check-percent {
-      border: 2px solid var(--check-color);
-
-      i {
-        color: var(--check-color);
+    .i-bar-item.is-#{$status} {
+      --check-color: rgba(var(--c-#{$status}-rgb), 0.8);
+  
+      &:hover,
+      &:focus {
+        background: rgba(var(--c-#{$status}-rgb), 0.05);
       }
-    }
-
+  
+      .i-bar-check-initial {
+        background: var(--c-success);
+      }
+  
+      .i-bar-check-completed,
+      .i-bar-check-percent {
+        border: 2px solid var(--check-color);
+  
+        i {
+          color: var(--check-color);
+  
+        }
+      }
     circle {
       fill: var(--check-color);
     }

--- a/assets/sass/components/_issue-sidebar.scss
+++ b/assets/sass/components/_issue-sidebar.scss
@@ -23,7 +23,7 @@
     @extend .shared-btn-styles;
     color: var(--c-blue)  !important;
     background: var(--c-transparent-blue) !important;
-    margin-bottom: 1rem;
+    margin-bottom: 2.5rem;
   }
 }
 

--- a/assets/sass/components/_issue.scss
+++ b/assets/sass/components/_issue.scss
@@ -32,11 +32,17 @@ body.issue {
 
   .issue-content {
     h1 {
-      font-size: 3rem;
-      font-weight: 700;
-      text-align: left;
-      margin: -0.5rem 0 2rem 0;
-    }
+        font-size: 2rem;
+        font-weight: 700;
+        text-align: left;
+        margin: -0.5rem 0 2rem 0;
+    
+        @media screen and (min-width: $bp-medium) {
+          font-size: 3rem;
+    
+        }
+    
+      }
 
     p,
     li,

--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -15,6 +15,7 @@ enum ComponentLocationState {
   EnterManually,
 }
 
+
 interface State {
   componentLocationState: ComponentLocationState;
   manualAddress: string | undefined;
@@ -41,19 +42,21 @@ class Location extends React.Component<WithLocationProps & WithCompletedProps, S
   }
 
   componentDidUpdate(prevProps: Readonly<WithLocationProps & WithCompletedProps>): void {
-    // if we have a location, update the issue completion
-    if (JSON.stringify(prevProps.completedIssueMap) !== JSON.stringify(this.props.completedIssueMap)) {
+    const prevPropsIssueCount = Object.keys(prevProps.completedIssueMap ?? {}).length;
+    const currentPropsIssueCount = Object.keys(this.props.completedIssueMap ?? {}).length;
+    if (prevPropsIssueCount !== currentPropsIssueCount) {
       this.updateIssueCompletion();
     }
   }
 
 
-  // "what the fuck is jquery doing in react?"
-  // well, we have a bunch of static html on the page that we'd likely to modify
-  // without having to render again in react, plus rerender flashes are ugly
-  // so instead we do some light modification with jquery
+  // // "what the fuck is jquery doing in react?"
+  // // well, we have a bunch of static html on the page that we'd likely to modify
+  // // without having to render again in react, plus rerender flashes are ugly
+  // // so instead we do some light modification with jquery
   updateIssueCompletion = () => {
     const completedIssueIds = Object.keys(this.props.completedIssueMap || {})
+    if (completedIssueIds.length === 0) return
     $(".i-bar-list-section .i-bar-item-check>div").each((_, el) => {
       const itemIssueID = $(el).data("issue-id") as string;
 

--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -50,10 +50,10 @@ class Location extends React.Component<WithLocationProps & WithCompletedProps, S
   }
 
 
-  // // "what the fuck is jquery doing in react?"
-  // // well, we have a bunch of static html on the page that we'd likely to modify
-  // // without having to render again in react, plus rerender flashes are ugly
-  // // so instead we do some light modification with jquery
+  // "what the fuck is jquery doing in react?"
+  // well, we have a bunch of static html on the page that we'd likely to modify
+  // without having to render again in react, plus rerender flashes are ugly
+  // so instead we do some light modification with jquery
   updateIssueCompletion = () => {
     const completedIssueIds = Object.keys(this.props.completedIssueMap || {})
     if (completedIssueIds.length === 0) return

--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -40,7 +40,7 @@ class Location extends React.Component<WithLocationProps & WithCompletedProps, S
     this.updateIssueCompletion();
   }
 
-  componentDidUpdate(prevProps: Readonly<WithLocationProps & WithCompletedProps>, prevState: Readonly<State>, snapshot?: any): void {
+  componentDidUpdate(prevProps: Readonly<WithLocationProps & WithCompletedProps>): void {
     // if we have a location, update the issue completion
     if (JSON.stringify(prevProps.completedIssueMap) !== JSON.stringify(this.props.completedIssueMap)) {
       this.updateIssueCompletion();

--- a/react/src/components/Reps.tsx
+++ b/react/src/components/Reps.tsx
@@ -76,10 +76,11 @@ class Reps extends React.Component<Props & WithLocationProps & WithCompletedProp
           group: this.props.callingGroup,
         };
         postOutcomeData(outcomeData);
-        this.props.setNeedsCompletionFetch(true);
       }
 
-      if (this.state.activeContactIndex < contacts.length - 1) {
+      const isFinished = this.state.activeContactIndex >= contacts.length - 1
+
+      if (!isFinished) {
         const activeContactIndex = this.state.activeContactIndex + 1;
         this.setState({ activeContactIndex });
         this.reportUpdatedActiveContact(contacts[activeContactIndex]);
@@ -87,11 +88,18 @@ class Reps extends React.Component<Props & WithLocationProps & WithCompletedProp
           .getElementById("reps-header")
           ?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
       } else {
-          // if we load the next page too soon, the previous outcome is sometimes skipped
-          // 300ms is something arbitrary I picked
-          setTimeout(() => {
-            window.location.pathname = window.location.pathname + "/done/";
-          }, 300);
+        this.props.setCompletedIssueMap({
+          [this.state.issueId]: Date.now()
+        })
+
+        const event = new CustomEvent("nextContact", { detail: outcome });
+        document.dispatchEvent(event);
+
+        // if we load the next page too soon, the previous outcome is sometimes skipped
+        // 300ms is something arbitrary I picked
+        setTimeout(() => {
+          window.location.pathname = window.location.pathname + "/done/";
+        }, 300);
       }
     });
   }
@@ -171,17 +179,17 @@ class Reps extends React.Component<Props & WithLocationProps & WithCompletedProp
     if (!this.state.contactList || !this.props.locationState?.address) {
       return (
         <div ref={this.componentRef}>
-        <ul >
-          <li>
-            <img alt="No representative found" src="/images/no-rep.png" />
-            <h4>No reps available</h4>
-            <p>Please set your location to find your representatives</p>
-          </li>
-        </ul>
+          <ul >
+            <li>
+              <img alt="No representative found" src="/images/no-rep.png" />
+              <h4>No reps available</h4>
+              <p>Please set your location to find your representatives</p>
+            </li>
+          </ul>
         </div>
       );
     }
-    
+
     const contacts = this.contactsForArea(this.state.areas, this.state.contactList);
     let activeContact: Contact | undefined;
     if (contacts.length > 0) {

--- a/react/src/components/Reps.tsx
+++ b/react/src/components/Reps.tsx
@@ -91,10 +91,7 @@ class Reps extends React.Component<Props & WithLocationProps & WithCompletedProp
         this.props.setCompletedIssueMap({
           [this.state.issueId]: Date.now()
         })
-
-        const event = new CustomEvent("nextContact", { detail: outcome });
-        document.dispatchEvent(event);
-
+        
         // if we load the next page too soon, the previous outcome is sometimes skipped
         // 300ms is something arbitrary I picked
         setTimeout(() => {

--- a/react/src/state/appState.ts
+++ b/react/src/state/appState.ts
@@ -1,7 +1,7 @@
 import { LocationState } from "../state/locationState";
-import { CompletedState } from "../state/completedState";
+import { CompletedIssueMap } from "../state/completedState";
 
 export interface ApplicationState {
   locationState?: LocationState;
-  completedState?: CompletedState;
+  completedIssueMap?: CompletedIssueMap;
 }

--- a/react/src/state/completedState.ts
+++ b/react/src/state/completedState.ts
@@ -1,20 +1,15 @@
 import React from "react";
 
-export type CompletionMap = { [issueID: number]: number };
+// where the value is the timestamp of when the issue was completed
+export type CompletedIssueMap = { [issueID: number]: number };
 
-export const CompletedContext = React.createContext<WithCompletedProps>({
-  completed: undefined,
-  setCompleted: () => {},
-  setNeedsCompletionFetch: () => {},
+export const CompletedContext = React.createContext({
+  completedIssueMap: {} as CompletedIssueMap,
+  setCompletedIssueMap: () => {
+  },
 });
 
-export interface CompletedState {
-  needsCompletionFetch: boolean;
-  completed: CompletionMap;
-}
-
 export type WithCompletedProps = {
-  completed?: CompletedState;
-  setCompleted(completed: CompletionMap): void;
-  setNeedsCompletionFetch(needsRefresh: boolean): void;
+  completedIssueMap?: CompletedIssueMap;
+  setCompletedIssueMap(completedIssueMap: CompletedIssueMap): void;
 };

--- a/react/src/utils/api.ts
+++ b/react/src/utils/api.ts
@@ -9,7 +9,6 @@ import { ContactList } from "../common/models/contactList";
 import * as Constants from "../common/constants";
 import { OutcomeData } from "../common/models/contactEvent";
 import { UserCallDetails } from "../common/models/userStats";
-import { CompletionMap } from "../state/completedState";
 import uuid from "./uuid";
 
 const prepareHeaders = async (): Promise<Headers> => {
@@ -120,26 +119,6 @@ export const postOutcomeData = async (data: OutcomeData) => {
       return Promise.resolve(null);
     })
     .catch((e) => Promise.reject(e));
-};
-
-interface CompletedIssuesResponse {
-  completed: CompletionMap;
-}
-
-export const getCompletedIssues = async (): Promise<CompletionMap> => {
-  const headers = await prepareHeaders();
-
-  return axios
-    .get<CompletedIssuesResponse>(`${Constants.COMPLETED_API_URL}`, {
-      headers: headers,
-    })
-    .then((result) => {
-      return Promise.resolve(result.data.completed);
-    })
-    .catch((error) => {
-      console.error("couldn't get completed issues", error);
-      return Promise.reject(error);
-    });
 };
 
 export const getUserCallDetails = (idToken: string) => {

--- a/react/src/utils/storage.ts
+++ b/react/src/utils/storage.ts
@@ -3,7 +3,7 @@ import { ApplicationState } from "../state/appState";
 import { CompletedIssueMap,  } from "../state/completedState";
 
 const LOCATION_KEY = "persist:fivecalls";
-const COMPLETION_KEY = 'persist:fivecalls-completion';
+const COMPLETION_KEY = 'persist:fivecalls-completedIssueMap';
 
 const saveLocation = (location: LocationState) => {
 

--- a/react/src/utils/storage.ts
+++ b/react/src/utils/storage.ts
@@ -1,36 +1,34 @@
 import { LocationState } from "../state/locationState";
 import { ApplicationState } from "../state/appState";
-import { CompletedState } from "../state/completedState";
+import { CompletedIssueMap,  } from "../state/completedState";
 
-const LocalStorageKey = "persist:fivecalls";
+const LOCATION_KEY = "persist:fivecalls";
+const COMPLETION_KEY = 'persist:fivecalls-completion';
 
 const saveLocation = (location: LocationState) => {
-  const storage = getStorageAsObject();
 
   const newStoredData: StoredData = {
     locationState: JSON.stringify(location),
-    completedState: JSON.stringify(storage.completedState),
-  };
-  localStorage.setItem(LocalStorageKey, JSON.stringify(newStoredData));
+}
+  localStorage.setItem(LOCATION_KEY, JSON.stringify(newStoredData));
 };
 
-const saveCompleted = (completed: CompletedState) => {
-  const storage = getStorageAsObject();
-
-  const newStoredData: StoredData = {
-    locationState: JSON.stringify(storage.locationState),
-    completedState: JSON.stringify(completed),
-  };
-  localStorage.setItem(LocalStorageKey, JSON.stringify(newStoredData));
+const saveCompleted = (completedIssueMap: CompletedIssueMap) => {
+  localStorage.setItem(COMPLETION_KEY, JSON.stringify(completedIssueMap));
 };
 
 const getStorageAsObject = (): ApplicationState => {
-  const storageString = localStorage.getItem(LocalStorageKey) ?? "{}";
-  const data: StoredData = JSON.parse(storageString) as StoredData;
-  const locationState = JSON.parse(data.locationState ?? "{}") as LocationState;
-  const completedState = JSON.parse(data.completedState ?? "{}") as CompletedState;
+  const getStoredState = <T>(key: string): T => {
+    const storageString = localStorage.getItem(key) ?? "{}";
+    return JSON.parse(storageString) as T;
+  };
 
-  const appState: ApplicationState = { locationState: locationState, completedState: completedState };
+  const locationData: StoredData = getStoredState<StoredData>(LOCATION_KEY);
+  const locationState = JSON.parse(locationData.locationState ?? "{}") as LocationState;
+
+  const completedIssueMap = getStoredState<StoredData>(COMPLETION_KEY) as CompletedIssueMap;
+
+  const appState: ApplicationState = { locationState, completedIssueMap };
   return appState;
 };
 
@@ -44,7 +42,7 @@ interface StoredData {
 
 interface Storage {
   saveLocation(location: LocationState): void;
-  saveCompleted(completed: CompletedState): void;
+  saveCompleted(completed: CompletedIssueMap): void;
   getStorageAsObject(): ApplicationState;
 }
 


### PR DESCRIPTION
## Before

_even though I completed the calls, I don't see any indication in the UI_
![Screenshot 2025-03-21 at 9 52 26 PM](https://github.com/user-attachments/assets/c1893963-7f2e-4965-8a1e-4d2d3507fe05)


## After
_now after I complete calls I get the checkbox that was there originally before the logic got broken_
![Screenshot 2025-03-21 at 9 52 06 PM](https://github.com/user-attachments/assets/19a1c4b5-69bb-4228-802f-e9737d5ec7df)

## Changes

- Add a new localStorage item that looks like this (second item, first item should remain totally untouched as that determines the location):

![Screenshot 2025-03-21 at 10 03 01 PM](https://github.com/user-attachments/assets/f9621718-9509-48e1-8234-eb9153a9f807)

- Add timestamp data, we don't do anything with it yet though!

- Remove all logic that expects backend to return completion state

- A few minor typography and style updates


## Notes
This pr basically just fixes a bug, but in the future I would be definitely interested in exploring new UI for this data.