### PR TITLE
[UI Fix][Small] Improve mobile friendlinesss of location input

### DIFF
--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -5,7 +5,7 @@ form {
 }
 
 ::placeholder {
-  color: var(--c-dark);
+  color: var(--c-base-subtle);
 }
 
 input {

--- a/assets/sass/components/_issue-sidebar.scss
+++ b/assets/sass/components/_issue-sidebar.scss
@@ -108,7 +108,7 @@
     justify-content: center;
 
     input {
-      width: 75%;
+      width: 100%;
       border: 0;
       margin-right: 0.5rem;
     }
@@ -116,9 +116,6 @@
     @media screen and (min-width: 40rem) {
       justify-content: flex-start;
 
-      input {
-        width: 75%;
-      }
     }
 
     button {
@@ -140,9 +137,6 @@
 
 .i-bar-loading,
 .i-bar-location form {
-  max-width: 14rem;
-  margin-left: auto;
-  margin-right: auto;
 
   @media screen and (min-width: 40rem) {
     max-width: unset;


### PR DESCRIPTION
I know we're planning on redoing this component at some point but I thought this was an improvement that was worth pushing now.

When QAing on mobile I kind of struggle to click the input, it is very small. So I just make it full width which is best practice on mobile.

I also made the placeholder text more subtle so that it doesn't look like pre-filled information -- placeholder text is almost always grayed out.

| Header | Header |
|--------|--------|
| Before | ![Screenshot 2025-03-28 at 1 41 10 PM](https://github.com/user-attachments/assets/a67db25e-ad3f-4edc-b438-6c664ec75685)|
| After | ![Screenshot 2025-03-28 at 1 44 10 PM](https://github.com/user-attachments/assets/71bad138-02d4-49c5-9c22-02a908d96062) | 