### PR TITLE
fix(#72): open links in new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,8 @@
+{{- $u := urls.Parse .Destination -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $u.IsAbs }} rel="external nofollow noopener" target="_blank"{{ end -}}
+>
+  {{- with .Text }}{{ . }}{{ end -}}
+</a>
+{{- /* chomp trailing newline */ -}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,7 +1,7 @@
 {{- $u := urls.Parse .Destination -}}
 <a href="{{ .Destination | safeURL }}"
   {{- with .Title }} title="{{ . }}"{{ end -}}
-  {{- if $u.IsAbs }} rel="external nofollow noopener" target="_blank"{{ end -}}
+  {{- if $u.IsAbs }} target="_blank"{{ end -}}
 >
   {{- with .Text }}{{ . }}{{ end -}}
 </a>


### PR DESCRIPTION
Fixes https://github.com/5calls/static/issues/72

Hugo has the concept of [render hooks](https://gohugo.io/render-hooks/links/). These allow you to change how some default markdown elements are rendered from Markdown to HTML. This can be used when rendering links to ensure they get a `target=_blank`.

Ex (I don't have a better way to show this lol): 
![image](https://github.com/user-attachments/assets/52c5f599-54e5-4a76-9d10-e7e4a2c0a2ec)



I also added some logic to ensure it is only external links that are getting opened in new tabs. This can be changed if needed.

The code is mostly pulled from here https://gohugo.io/render-hooks/links/#examples

Love the project BTW.