### PR TITLE
Bail on geolocation for manual input if it fails

### DIFF
--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -28,6 +28,7 @@ const Location: React.FC<WithLocationProps & WithCompletedProps> = (props) => {
   const [manualAddress, setManualAddress] = useState<string | undefined>(
     undefined
   );
+  const [hasGeolocationFailed, setHasGeolocationFailed] = useState<boolean>(false);
 
   useEffect(() => {
     if (props.locationState && props.locationState.address) {
@@ -88,6 +89,13 @@ const Location: React.FC<WithLocationProps & WithCompletedProps> = (props) => {
 
   const setLocationAutomatically = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    // if we've previously had geolocation fail, go to manually set location
+    if (hasGeolocationFailed) {
+      setComponentLocationState(ComponentLocationState.EnterManually);
+      return;
+    }
+
     setComponentLocationState(ComponentLocationState.GettingAutomatically);
 
     // close any possibly open toasts to prevent user confusion
@@ -105,12 +113,10 @@ const Location: React.FC<WithLocationProps & WithCompletedProps> = (props) => {
           .catch((error) => {
             console.log('error getting location after geoloc:', error);
             toast.error(ERROR_MESSAGE);
+            setHasGeolocationFailed(true);
             setComponentLocationState(ComponentLocationState.NoLocation);
           });
       })
-      .catch(() => {
-        setComponentLocationState(ComponentLocationState.EnterManually);
-      });
   };
 
   switch (componentLocationState) {

--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -28,7 +28,8 @@ const Location: React.FC<WithLocationProps & WithCompletedProps> = (props) => {
   const [manualAddress, setManualAddress] = useState<string | undefined>(
     undefined
   );
-  const [hasGeolocationFailed, setHasGeolocationFailed] = useState<boolean>(false);
+  const [hasGeolocationFailed, setHasGeolocationFailed] =
+    useState<boolean>(false);
 
   useEffect(() => {
     if (props.locationState && props.locationState.address) {
@@ -116,7 +117,8 @@ const Location: React.FC<WithLocationProps & WithCompletedProps> = (props) => {
             setHasGeolocationFailed(true);
             setComponentLocationState(ComponentLocationState.NoLocation);
           });
-      }).catch(() => {
+      })
+      .catch(() => {
         // this is failure of geolocation permission
         setComponentLocationState(ComponentLocationState.EnterManually);
       });

--- a/react/src/components/Location.tsx
+++ b/react/src/components/Location.tsx
@@ -116,7 +116,10 @@ const Location: React.FC<WithLocationProps & WithCompletedProps> = (props) => {
             setHasGeolocationFailed(true);
             setComponentLocationState(ComponentLocationState.NoLocation);
           });
-      })
+      }).catch(() => {
+        // this is failure of geolocation permission
+        setComponentLocationState(ComponentLocationState.EnterManually);
+      });
   };
 
   switch (componentLocationState) {

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -51,7 +51,7 @@ $(() => {
   // Set the district tag in the newsletter form if district exists
   const district = localStorage.getItem(LOCAL_STORAGE_KEYS.DISTRICT);
   const districtTagInput = document.getElementById('district-tag');
-  
+
   if (district && districtTagInput) {
     districtTagInput.setAttribute('value', district);
   } else if (districtTagInput) {


### PR DESCRIPTION
Sometimes folks calling from overseas would say they could not set an address manually. This makes sense as we were constantly trying to navigate from the `NoLocation` state to the `GettingAutomatically` state even if it had previously failed. Instead, set the state to `EnterManually` if the server response from the reps endpoint returns an error.