### PR TITLE
Added full text issue search in the sidebar

### DIFF
--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -18,7 +18,8 @@
     box-shadow: none;
   }
 
-  i, .card-home-icon {
+  i,
+  .card-home-icon {
     font-size: 5em;
     display: block;
     text-align: center;
@@ -53,7 +54,8 @@
       text-align: left;
     }
 
-    i, .card-home-icon {
+    i,
+    .card-home-icon {
       font-size: 2em;
       margin: 0 var(--g-gap) 0 0;
     }
@@ -77,7 +79,8 @@
       font-weight: 700;
     }
 
-    i, .card-home-icon {
+    i,
+    .card-home-icon {
       font-size: 3.5em;
       color: var(--c-dark);
     }

--- a/assets/sass/components/_issue-sidebar.scss
+++ b/assets/sass/components/_issue-sidebar.scss
@@ -285,3 +285,69 @@
 @include i-bar-color("urgent");
 @include i-bar-color("momentum");
 @include i-bar-color("unsorted");
+
+// Search component styles
+.i-bar-search {
+  margin-bottom: 1rem;
+}
+
+.i-bar-search-input {
+  position: relative;
+  margin-bottom: 0.5rem;
+}
+
+.i-bar-search-field {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid rgba(25, 27, 29, 0.4);
+  border-radius: 0;
+  font-size: 1rem;
+  padding-right: 2.5rem;
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 4px rgb(170, 191, 221);
+    border-color: var(--c-blue);
+  }
+}
+
+.i-bar-search-clear {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  padding: 0.25rem;
+
+  &:hover {
+    color: #333;
+  }
+}
+
+.i-bar-search-loading {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  color: #666;
+  font-size: 0.9rem;
+
+  i {
+    margin-right: 0.5rem;
+  }
+}
+
+.i-bar-search-results {
+  border: none;
+  border-radius: 0;
+  background: #fff;
+}
+
+.i-bar-search-no-results {
+  padding: 1rem;
+  text-align: center;
+  color: #666;
+  font-style: italic;
+}

--- a/assets/sass/components/_issue-sidebar.scss
+++ b/assets/sass/components/_issue-sidebar.scss
@@ -288,18 +288,20 @@
 
 // Search component styles
 .i-bar-search {
-  margin-bottom: 1rem;
+  margin-bottom: 0;
 }
 
-.i-bar-search-input {
+.i-bar-search-field {
   position: relative;
   margin-bottom: 0.5rem;
 }
 
-.i-bar-search-field {
+.i-bar-search-input[type="text"] {
   width: 100%;
   padding: 0.75rem;
-  border: 1px solid rgba(25, 27, 29, 0.4);
+  border: 0;
+  border-top: 2px solid var(--c-blue);
+  border-bottom: 2px solid var(--c-blue);
   border-radius: 0;
   font-size: 1rem;
   padding-right: 2.5rem;

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -8,10 +8,11 @@
   </div>
 
   <div class="i-bar-list">
+    <header class="i-bar-header i-bar-header-unsorted">
+      <h3><i class="fa fa-newspaper"></i> What's important to you?</h3>
+    </header>
+    <div id="react-search"></div>
     <section class="i-bar-list-section">
-      <header class="i-bar-header i-bar-header-unsorted">
-        <h3><i class="fa fa-newspaper"></i> What’s important to you?</h3>
-      </header>
 
       <!-- prettier-ignore -->
       {{ $passedIssueID := (.Scratch.Get "issueId")}}

--- a/react/src/components/IssueSearch.tsx
+++ b/react/src/components/IssueSearch.tsx
@@ -92,12 +92,23 @@ const IssueSearch: React.FC<IssueSearchProps> = () => {
     }
 
     const lowercaseSearch = searchTerm.toLowerCase();
-    return issues.filter(
+    const filtered = issues.filter(
       (issue) =>
         issue.name.toLowerCase().includes(lowercaseSearch) ||
         issue.reason.toLowerCase().includes(lowercaseSearch) ||
+        issue.script.toLowerCase().includes(lowercaseSearch) ||
         issue.slug.toLowerCase().includes(lowercaseSearch)
     );
+
+    // Sort to prioritize name matches first
+    return filtered.sort((a, b) => {
+      const aNameMatch = a.name.toLowerCase().includes(lowercaseSearch);
+      const bNameMatch = b.name.toLowerCase().includes(lowercaseSearch);
+      
+      if (aNameMatch && !bNameMatch) return -1;
+      if (!aNameMatch && bNameMatch) return 1;
+      return 0; // Both have same priority (both name matches or both non-name matches)
+    });
   };
 
   const filteredIssues = filterIssues(state.issues, state.searchTerm);
@@ -105,7 +116,7 @@ const IssueSearch: React.FC<IssueSearchProps> = () => {
 
   return (
     <div className="i-bar-search">
-      <div className="i-bar-search-input">
+      <div className="i-bar-search-field">
         <input
           ref={searchInputRef}
           type="text"
@@ -114,7 +125,7 @@ const IssueSearch: React.FC<IssueSearchProps> = () => {
           onChange={handleSearchChange}
           onFocus={handleSearchFocus}
           onBlur={handleSearchBlur}
-          className="i-bar-search-field"
+          className="i-bar-search-input"
         />
         {state.searchTerm && (
           <button

--- a/react/src/components/IssueSearch.tsx
+++ b/react/src/components/IssueSearch.tsx
@@ -1,0 +1,169 @@
+import React, { useState, useEffect, useRef } from 'react';
+import axios from 'axios';
+import * as Constants from '../common/constants';
+import { Issue } from '../common/models/issue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface IssueSearchProps {}
+
+interface SearchState {
+  searchTerm: string;
+  issues: Issue[];
+  isLoading: boolean;
+  isSearchFocused: boolean;
+  hasSearched: boolean;
+}
+
+const IssueSearch: React.FC<IssueSearchProps> = () => {
+  const [state, setState] = useState<SearchState>({
+    searchTerm: '',
+    issues: [],
+    isLoading: false,
+    isSearchFocused: false,
+    hasSearched: false
+  });
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Toggle visibility of static issues list based on search term
+    const staticSection = document.querySelector('.i-bar-list-section');
+    if (staticSection) {
+      const shouldHide = state.searchTerm.length >= 3;
+      (staticSection as HTMLElement).style.display = shouldHide ? 'none' : '';
+    }
+  }, [state.searchTerm]);
+
+  const fetchIssues = async (): Promise<Issue[]> => {
+    const response = await axios.get<Issue[]>(Constants.ISSUES_API_URL);
+    return response.data;
+  };
+
+  const handleSearchFocus = async () => {
+    if (!state.isSearchFocused && !state.hasSearched) {
+      setState((prev) => ({ ...prev, isSearchFocused: true, isLoading: true }));
+
+      try {
+        const issues = await fetchIssues();
+        setState((prev) => ({
+          ...prev,
+          issues,
+          isLoading: false,
+          hasSearched: true
+        }));
+      } catch (error) {
+        console.error('Failed to fetch issues:', error);
+        setState((prev) => ({ ...prev, isLoading: false }));
+      }
+    } else {
+      setState((prev) => ({ ...prev, isSearchFocused: true }));
+    }
+  };
+
+  const handleSearchBlur = () => {
+    // Don't hide search results on blur - let users click elsewhere and return
+    // Only hide if search is empty
+    if (!state.searchTerm) {
+      setTimeout(() => {
+        setState((prev) => ({ ...prev, isSearchFocused: false }));
+      }, 150);
+    }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchTerm = e.target.value;
+    setState((prev) => ({ ...prev, searchTerm }));
+  };
+
+  const clearSearch = () => {
+    setState((prev) => ({
+      ...prev,
+      searchTerm: '',
+      isSearchFocused: false
+    }));
+    if (searchInputRef.current) {
+      searchInputRef.current.blur();
+    }
+  };
+
+  const filterIssues = (issues: Issue[], searchTerm: string): Issue[] => {
+    if (!searchTerm || searchTerm.length < 3) {
+      return [];
+    }
+
+    const lowercaseSearch = searchTerm.toLowerCase();
+    return issues.filter(
+      (issue) =>
+        issue.name.toLowerCase().includes(lowercaseSearch) ||
+        issue.reason.toLowerCase().includes(lowercaseSearch) ||
+        issue.slug.toLowerCase().includes(lowercaseSearch)
+    );
+  };
+
+  const filteredIssues = filterIssues(state.issues, state.searchTerm);
+  const shouldShowSearchResults = state.searchTerm.length >= 3;
+
+  return (
+    <div className="i-bar-search">
+      <div className="i-bar-search-input">
+        <input
+          ref={searchInputRef}
+          type="text"
+          placeholder="Search all issues..."
+          value={state.searchTerm}
+          onChange={handleSearchChange}
+          onFocus={handleSearchFocus}
+          onBlur={handleSearchBlur}
+          className="i-bar-search-field"
+        />
+        {state.searchTerm && (
+          <button
+            className="i-bar-search-clear"
+            onClick={clearSearch}
+            type="button"
+          >
+            <i className="fa fa-times"></i>
+          </button>
+        )}
+      </div>
+
+      {state.isLoading && (
+        <div className="i-bar-search-loading">
+          <i className="fa fa-spinner fa-spin"></i>
+          <span>Loading issues...</span>
+        </div>
+      )}
+
+      {shouldShowSearchResults && !state.isLoading && (
+        <div className="i-bar-search-results">
+          {filteredIssues.length > 0 ? (
+            filteredIssues.map((issue) => (
+              <a
+                key={issue.id}
+                className="i-bar-item is-unsorted"
+                href={`/issue/${issue.slug}/`}
+              >
+                <div className="i-bar-item-check">
+                  <div
+                    className="i-bar-check-completed"
+                    data-issue-id={issue.id}
+                  >
+                    <i className="fa fa-phone"></i>
+                    <span className="sr-only">Needs your calls</span>
+                  </div>
+                </div>
+                <strong>{issue.name}</strong>
+              </a>
+            ))
+          ) : (
+            <div className="i-bar-search-no-results">
+              No issues found matching &ldquo;{state.searchTerm}&rdquo;
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IssueSearch;

--- a/react/src/components/IssueSearch.tsx
+++ b/react/src/components/IssueSearch.tsx
@@ -104,7 +104,7 @@ const IssueSearch: React.FC<IssueSearchProps> = () => {
     return filtered.sort((a, b) => {
       const aNameMatch = a.name.toLowerCase().includes(lowercaseSearch);
       const bNameMatch = b.name.toLowerCase().includes(lowercaseSearch);
-      
+
       if (aNameMatch && !bNameMatch) return -1;
       if (!aNameMatch && bNameMatch) return 1;
       return 0; // Both have same priority (both name matches or both non-name matches)

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -18,6 +18,7 @@ import CallCount from './components/CallCount';
 import APIForm from './components/APIForm';
 import Settings from './components/Settings';
 import GroupCallCount from './components/GroupCallCount';
+import IssueSearch from './components/IssueSearch';
 import Bugsnag from '@bugsnag/js';
 import { Slide, ToastContainer } from 'react-toastify';
 import { LOCAL_STORAGE_KEYS } from './common/constants';
@@ -53,7 +54,6 @@ $(() => {
   checkForGCLID();
   checkForReferral();
 });
-
 
 // Set the district tag in the newsletter form if district exists
 const checkForDistrict = (): string | null => {
@@ -186,6 +186,7 @@ const startComponentRenders = () => {
     { id: 'react-call-count', component: CallCount },
     { id: 'api-form', component: APIForm },
     { id: 'react-settings', component: Settings },
+    { id: 'react-search', component: IssueSearch },
     {
       id: 'react-groupcounts',
       component: GroupCallCount,

--- a/react/src/utils/api.ts
+++ b/react/src/utils/api.ts
@@ -138,7 +138,11 @@ export const postGCLID = (gclid: string) => {
 };
 
 // sends a message to the server indicating a referral
-export const postReferral = (ref: string, path: string, meta: string | null) => {
+export const postReferral = (
+  ref: string,
+  path: string,
+  meta: string | null
+) => {
   const postData = querystring.stringify({
     ref: ref,
     meta: meta,


### PR DESCRIPTION
Added a search field at the top of the sidebar where users can type a search and find relevant issues that might not be on the front page. Searches title, description and slug.

Because we publish the sidebar statically, this loads the issues from the server on focus of the search box the first time.

Fixes #24 