### PR TITLE
Show vacant seat

### DIFF
--- a/assets/sass/components/_issue.scss
+++ b/assets/sass/components/_issue.scss
@@ -126,6 +126,10 @@ body.issue {
             text-decoration: underline;
           }
         }
+
+        .vacant {
+          opacity: 0.5;
+        }
       }
     }
 

--- a/assets/sass/components/_issue.scss
+++ b/assets/sass/components/_issue.scss
@@ -242,8 +242,10 @@ body.issue {
   }
 
   .issue-script {
-    background-color: #f5f5f5;
-    padding: 20px;
+    .contact-content {
+      background-color: #f5f5f5;
+      padding: 20px;
+    }
 
     p,
     li,

--- a/react/src/common/models/contact.ts
+++ b/react/src/common/models/contact.ts
@@ -16,3 +16,9 @@ export interface FieldOffice {
   city: string;
   phone: string;
 }
+
+export interface MissingSeat {
+  id: string;
+  reason: string;
+  area?: string;
+}

--- a/react/src/components/Script.tsx
+++ b/react/src/components/Script.tsx
@@ -82,9 +82,11 @@ class Script extends React.Component<WithLocationProps, State> {
   }
 
   render() {
-    let formattedScriptMarkdown = this.state.scriptMarkdown;
+    let formattedScriptMarkdown = this.state.currentContact
+      ? this.state.scriptMarkdown
+      : '';
 
-    if (this.props.locationState) {
+    if (this.props.locationState && this.state.currentContact) {
       formattedScriptMarkdown = this.scriptFormat(
         formattedScriptMarkdown,
         this.props.locationState,
@@ -94,8 +96,14 @@ class Script extends React.Component<WithLocationProps, State> {
 
     return (
       <span ref={this.scriptRef}>
-        {/* react-markdown is 20kb, we could probably find a lighter one */}
-        <ReactMarkdown>{formattedScriptMarkdown}</ReactMarkdown>
+        <div
+          className={
+            formattedScriptMarkdown.length > 0 ? 'contact-content' : ''
+          }
+        >
+          {/* react-markdown is 20kb, we could probably find a lighter one */}
+          <ReactMarkdown>{formattedScriptMarkdown}</ReactMarkdown>
+        </div>
       </span>
     );
   }


### PR DESCRIPTION
This handles #81. If less than 2 senators and/or less than 1 house rep, it shows the seat as vacant:

#### No house rep, house & senate issue
<img width="572" alt="vacant-house-house-senate" src="https://github.com/user-attachments/assets/5e234348-3303-4bbc-aa45-69a19b01de66" />

#### No house rep, just house issue
<img width="595" alt="vacant-house-just-house" src="https://github.com/user-attachments/assets/106ed782-8ea4-4af6-acb5-1bddab196cbe" />

#### Multiple vacancies (house & senate seat empty)
(just set a local var to test this)
<img width="440" alt="multiple-vacanies" src="https://github.com/user-attachments/assets/5045f1ca-ecb0-4509-a312-9a2e480e63de" />

#### No location set
<img width="551" alt="no-location-set" src="https://github.com/user-attachments/assets/83672e5a-40bb-4655-9d78-42e0daa2a04b" />


This also hides the script if the only contact is a vacant seat. 
