### PR TITLE
Always show house and senate reps

### DIFF
--- a/assets/sass/components/_issue.scss
+++ b/assets/sass/components/_issue.scss
@@ -127,6 +127,13 @@ body.issue {
           }
         }
 
+        .rep-info {
+          display: flex;
+          flex-direction: row;
+          align-items: flex-start;
+          gap: 6px;
+        }
+
         .vacant,
         .irrelevant {
           opacity: 0.5;

--- a/assets/sass/components/_issue.scss
+++ b/assets/sass/components/_issue.scss
@@ -90,7 +90,7 @@ body.issue {
         margin-left: 0;
         padding-left: 0;
         padding: 4px;
-        height: 50px;
+        height: fit-content;
         background-color: var(--c-xlight-base);
         border-left: 3px solid var(--c-xlight-base);
         overflow: hidden;
@@ -100,7 +100,7 @@ body.issue {
         }
 
         img {
-          margin: 3px 6px 0 3px;
+          margin: 3px 6px 6px 3px;
           width: 36px;
           height: 36px;
           border-radius: 18px;
@@ -121,13 +121,14 @@ body.issue {
 
         p {
           font-size: 15px;
-
+          margin-bottom: 0px;
           a {
             text-decoration: underline;
           }
         }
 
-        .vacant {
+        .vacant,
+        .irrelevant {
           opacity: 0.5;
         }
       }

--- a/react/src/common/models/contact.ts
+++ b/react/src/common/models/contact.ts
@@ -16,9 +16,3 @@ export interface FieldOffice {
   city: string;
   phone: string;
 }
-
-export interface MissingSeat {
-  id: string;
-  reason: string;
-  area?: string;
-}

--- a/react/src/components/Reps.tsx
+++ b/react/src/components/Reps.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 
 import { toast } from 'react-toastify';
-import { Contact, MissingSeat } from '../common/models/contact';
+import { Contact, Party } from '../common/models/contact';
 import { OutcomeData } from '../common/models/contactEvent';
 import { ContactArea, ContactList } from '../common/models/contactList';
 import { WithCompletedProps } from '../state/completedState';
@@ -27,6 +27,8 @@ const TOAST_SETTINGS = {
   autoClose: 2500,
   position: 'bottom-center'
 };
+
+const ALWAYS_VISIBLE_AREAS = [ContactArea.USHouse, ContactArea.USSenate];
 
 const TOAST_DELAY = 750;
 
@@ -105,7 +107,7 @@ class Reps extends React.Component<
 
     if (!this.state.contactList) {
       // if we don't have contacts, fetch the contacts
-      this.updateContacts(areaString);
+      this.updateContacts(areaString.split(','));
     }
 
     document.addEventListener('nextContact', (e) => {
@@ -177,7 +179,7 @@ class Reps extends React.Component<
     if (
       prevProps.locationState?.address !== this.props.locationState?.address
     ) {
-      this.updateContacts(this.state.areas.join(','));
+      this.updateContacts(this.state.areas);
     }
   }
 
@@ -190,9 +192,21 @@ class Reps extends React.Component<
     document.dispatchEvent(activeContactEvent);
   }
 
-  updateContacts(areas: string = '') {
+  addAlwaysAvailableAreas(areas: string[]) {
+    const irrelevantVisibleAreas = [];
+    for (const area of ALWAYS_VISIBLE_AREAS) {
+      if (!areas.includes(area)) irrelevantVisibleAreas.push(area);
+    }
+    return [...areas, ...irrelevantVisibleAreas];
+  }
+
+  updateContacts(areas: string[] = []) {
+    // Make sure we're fetching all reps even if irrelevant
+    const completeAreas = this.addAlwaysAvailableAreas(areas);
+    const completeAreasString = completeAreas.join(',');
+
     if (this.props.locationState) {
-      getContacts(this.props.locationState.address, areas)
+      getContacts(this.props.locationState.address, completeAreasString)
         .then((contactList) => {
           this.setState({ activeContactIndex: 0, contactList });
           const contacts = this.contactsForArea(this.state.areas, contactList);
@@ -214,7 +228,7 @@ class Reps extends React.Component<
     let contacts: Contact[] = [];
 
     contacts = ContactUtils.allContacts(contactList).filter((contact) => {
-      for (const area of this.state.areas) {
+      for (const area of areas) {
         if (area === contact.area) {
           return true;
         }
@@ -225,35 +239,75 @@ class Reps extends React.Component<
     return contacts;
   }
 
-  vacantSeats(areas: string[], contactList: ContactList): MissingSeat[] {
-    const missingSeats: MissingSeat[] = [];
+  visibleIrrelevantContacts(
+    areas: string[],
+    contactList: ContactList
+  ): Contact[] {
+    let contacts: Contact[] = [];
 
-    if (areas.includes(ContactArea.USSenate)) {
-      // Handle missing Senate seat(s)
-      const senateReps = contactList.senateReps();
-      if (senateReps.length < 2) {
-        // Assuming Senate seat(s) is vacant if there's < 2
-        const numVacancies = 2 - senateReps.length; // handle multiple vacancies
-        for (let i = 0; i < numVacancies; i++) {
-          missingSeats.push({
-            id: `vacant-senate-seat-${i + 1}`,
-            reason: `This ${ContactArea.USSenate} seat is currently vacant.`,
-            area: ContactArea.USSenate
-          });
+    // filter out the relevant contacts
+    contacts = ContactUtils.allContacts(contactList)
+      .filter((contact) => {
+        for (const area of areas) {
+          if (area === contact.area) {
+            return false;
+          }
         }
-      }
-    }
-    if (areas.includes(ContactArea.USHouse)) {
-      // Handle missing House seat
-      const houseReps = contactList.houseRep();
-      // Assuming House seat is vacant if there's not at least one
-      if (houseReps.length < 1) {
+        return true;
+      })
+      .map((contact) => {
+        return {
+          ...contact,
+          reason: `${contact.area === ContactArea.USHouse ? 'House reps' : 'Senators'} are not currently relevant to this issue.`
+        };
+      });
+
+    return contacts;
+  }
+
+  vacantSeats(areas: string[], contactList: ContactList): Contact[] {
+    const missingSeats: Contact[] = [];
+    const party: Party = '';
+    const commonVacantSeatProps = {
+      name: 'Vacant Seat',
+      phone: '',
+      party,
+      state: contactList.state
+    };
+
+    // Handle missing Senate seat(s)
+    const senateReps = contactList.senateReps();
+    if (senateReps.length < 2) {
+      // Assuming Senate seat(s) is vacant if there's < 2
+      const numVacancies = 2 - senateReps.length; // handle multiple vacancies
+      for (let i = 0; i < numVacancies; i++) {
         missingSeats.push({
-          id: 'vacant-house-seat',
-          reason: `This ${ContactArea.USHouse} seat is currently vacant.`,
-          area: ContactArea.USHouse
+          id: `vacant-senate-seat-${i + 1}`,
+          reason: `This ${ContactArea.USSenate} seat is currently vacant${
+            areas.includes(ContactArea.USSenate)
+              ? ''
+              : ' and not relevant to this issue'
+          }.`,
+          area: ContactArea.USSenate,
+          ...commonVacantSeatProps
         });
       }
+    }
+
+    // Handle missing House seat
+    const houseReps = contactList.houseRep();
+    // Assuming House seat is vacant if there's not at least one
+    if (houseReps.length < 1) {
+      missingSeats.push({
+        id: 'vacant-house-seat',
+        reason: `This ${ContactArea.USHouse} seat is currently vacant${
+          areas.includes(ContactArea.USHouse)
+            ? ''
+            : ' and not relevant to this issue'
+        }.`,
+        area: ContactArea.USHouse,
+        ...commonVacantSeatProps
+      });
     }
 
     return missingSeats;
@@ -262,7 +316,8 @@ class Reps extends React.Component<
   contactComponent(
     contact: Contact,
     index: number,
-    activeIndex: number
+    activeIndex: number,
+    type: 'targeted' | 'irrelevant' | 'vacant'
   ): JSX.Element {
     let photoURL = '/images/no-rep.png';
     if (contact.photoURL && contact.photoURL !== '') {
@@ -271,36 +326,19 @@ class Reps extends React.Component<
 
     return (
       <li className={index === activeIndex ? 'active' : ''} key={contact.id}>
-        <img
-          alt={contact.name}
-          src={photoURL}
-          onError={(e) => {
-            e.currentTarget.src = '/images/no-rep.png';
-          }}
-        />
-        <h4>
-          {contact.name} ({ContactUtils.partyAndState(contact)})
-        </h4>
-        <p>{contact.reason}</p>
-      </li>
-    );
-  }
-
-  vacantSeatComponent(missing: MissingSeat): JSX.Element {
-    const photoURL = '/images/no-rep.png';
-
-    return (
-      <li key={missing.id}>
-        <div className="vacant">
+        <div className={type}>
           <img
-            alt={missing.id}
+            alt={contact.name}
             src={photoURL}
             onError={(e) => {
-              e.currentTarget.src = photoURL;
+              e.currentTarget.src = '/images/no-rep.png';
             }}
           />
-          <h4>Vacant Seat</h4>
-          <p>{missing.reason}</p>
+          <h4>
+            {contact.name}{' '}
+            {type !== 'vacant' && `(${ContactUtils.partyAndState(contact)})`}
+          </h4>
+          <p>{contact.reason}</p>
         </div>
       </li>
     );
@@ -321,28 +359,53 @@ class Reps extends React.Component<
       );
     }
 
-    const contacts = this.contactsForArea(
+    const targetedContacts = this.contactsForArea(
       this.state.areas,
       this.state.contactList
     );
 
-    const missingSeats = this.vacantSeats(
+    const irrelevantContacts = this.visibleIrrelevantContacts(
+      this.state.areas,
+      this.state.contactList
+    );
+
+    const vacantSeats = this.vacantSeats(
       this.state.areas,
       this.state.contactList
     );
 
     let activeContact: Contact | undefined;
-    if (contacts.length > 0) {
-      activeContact = contacts[this.state.activeContactIndex];
+    if (targetedContacts.length > 0) {
+      activeContact = targetedContacts[this.state.activeContactIndex];
     }
 
     return (
       <div ref={this.componentRef}>
         <ul>
-          {contacts.map((contact, index) =>
-            this.contactComponent(contact, index, this.state.activeContactIndex)
+          {targetedContacts.map((contact, index) =>
+            this.contactComponent(
+              contact,
+              index,
+              this.state.activeContactIndex,
+              'targeted'
+            )
           )}
-          {missingSeats.map((missing) => this.vacantSeatComponent(missing))}
+          {vacantSeats.map((contact) =>
+            this.contactComponent(
+              contact,
+              -1,
+              this.state.activeContactIndex,
+              'vacant'
+            )
+          )}
+          {irrelevantContacts.map((contact) =>
+            this.contactComponent(
+              contact,
+              -1,
+              this.state.activeContactIndex,
+              'irrelevant'
+            )
+          )}
         </ul>
         {activeContact && <ActiveContact contact={activeContact} />}
       </div>


### PR DESCRIPTION
* Implements #78 
* Contacts for both house and senate will always be shown on issues, regardless of relevancy
  * If a seat is vacant & irrelevant messaging shows this
* Also updates styling for contacts to make full contact text visible for longer text & smaller screens/windows - @nickoneill let me know if you want me to roll this back to the hidden text state though

**Irrelevant House**
<img width="414" alt="irrelevant-house" src="https://github.com/user-attachments/assets/c0048ec7-34ee-46d6-b344-7e0768a6684c" />

**Irrelevant Senate**
<img width="407" alt="irrelevant-senate" src="https://github.com/user-attachments/assets/e222b76d-3494-4a16-8e31-1eaf0c5b9bb8" />

**Irrelevant/Vacant Combo**
<img width="412" alt="all-irrelevant-vacant-combo" src="https://github.com/user-attachments/assets/b8c525ea-12cf-4c17-a4c6-2475159bffcf" />
