### PR TITLE
Fix map labels when the key has more height than the map

### DIFF
--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -100,8 +100,10 @@ const updateStateLabelPosition = (parent: SVGGraphicsElement) => {
   point.y = boundingBox.y + (1 / 2) * boundingBox.height;
   const screenCoords = point.matrixTransform(matrix);
 
-  const holderBb =
-    d3.select('div#state_map_content').node().getBoundingClientRect();
+  const holderBb = d3
+    .select('div#state_map_content')
+    .node()
+    .getBoundingClientRect();
   const svgOffsetY = svgBb.y - holderBb.y;
 
   screenCoords.y += svgOffsetY - 24; // 24 has to do with where the < is on the label.

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -101,7 +101,7 @@ const updateStateLabelPosition = (parent: SVGGraphicsElement) => {
   const screenCoords = point.matrixTransform(matrix);
 
   const holderBb =
-    parent.parentElement!.parentElement!.parentElement!.getBoundingClientRect();
+    d3.select('div#state_map_content').node().getBoundingClientRect();
   const svgOffsetY = svgBb.y - holderBb.y;
 
   screenCoords.y += svgOffsetY - 24; // 24 has to do with where the < is on the label.


### PR DESCRIPTION
Their Y position was off by a factor of the extra height of the key. Fixes the visual by grabbing the correct ancestor element by ID.