### PR TITLE
Add expand/collapse animated toggle section to each top issue info

### DIFF
--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -643,6 +643,11 @@
     min-width: 350px;
     border: 0.1rem solid var(--c-light-border);
     margin-bottom: 1rem;
+
+    .footnote {
+      padding: .5rem 1rem 1rem;
+      font-size: calc(16rem / var(--base-font-size));
+    }
   }
 
   #state_map_content {

--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -346,24 +346,33 @@
     @media (min-width: 40rem) {
       --row-font-size: calc(18rem / var(--base-font-size));
     }
+    --row-line-height: 1.1;
     font-size: var(--row-font-size);
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
 
-    button {
+    button.stat {
       background: #efefef;
     }
 
-    a {
+    a, button.issue_name {
       color: black;
       text-decoration: none;
       margin-right: 0.5rem;
       text-underline-offset: .1rem;
-      line-height: 1.1;
+      font-size: var(--row-font-size);
+      line-height: var(--row-line-height);
       transition: max-height 0.5s ease;
       max-height: 40rem;
+      min-height: initial;
       overflow: hidden;
+      background: none;
+      border: none;
+      padding: 0;
+      display: inline;
+      text-align: start;
+      white-space: initial;
 
       &:hover,
       &:focus {
@@ -372,37 +381,40 @@
       }
     }
 
-    a.short {
-      max-height: calc(1.1 * var(--row-font-size));
+    button.issue_name.short {
+      overflow: hidden;
+      white-space: initial;
+      max-height: calc(var(--row-line-height) * var(--row-font-size));
 
       @supports (-webkit-line-clamp: 2) {
-        max-height: calc(2 * 1.1 * var(--row-font-size));
+        max-height: calc(2 * var(--row-line-height) * var(--row-font-size));
+      }
+
+      @media (min-width: 40rem) {
+        max-height: calc(var(--row-line-height) * var(--row-font-size));
       }
     }
 
-    a.truncated {
+    button.issue_name.truncated {
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
       transition: max-height 0.5s ease;
-      max-height: calc(1.1 * var(--row-font-size));
+      max-height: calc(var(--row-line-height) * var(--row-font-size));
 
       @supports (-webkit-line-clamp: 2) {
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
         white-space: initial;
-        max-height: calc(2 * 1.1 * var(--row-font-size));
+        max-height: calc(2 * var(--row-line-height) * var(--row-font-size));
       }
 
       @media (min-width: 40rem) {
-        line-height: initial;
+        line-height: var(--row-line-height);
         white-space: nowrap;
-
-        @supports (-webkit-line-clamp: 2) {
-          display: block;
-          white-space: nowrap;
-        }
+        display: block;
+        max-height: calc(var(--row-line-height) * var(--row-font-size));
       }
     }
   }
@@ -439,7 +451,7 @@
       a {
         text-decoration: none;
         text-underline-offset: .1rem;
-        line-height: 1.1;
+        line-height: var(--row-line-height);
         font-weight: bold;
 
         &:hover,
@@ -452,6 +464,7 @@
 
     .row_detail.expanded {
       transition: max-height 0.5s ease;
+      overflow: visible;
       max-height: 50rem; /* must be larger than the tallest possible content */
     }
   }

--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -301,7 +301,6 @@
       li {
         counter-increment: top-counter;
         display: flex;
-        align-items: center;
         width: 100%;
         min-width: 20rem;
 
@@ -323,8 +322,6 @@
 
     .stat {
       margin-left: 5px;
-      margin-top: auto;
-      margin-bottom: auto;
       white-space: nowrap;
       font-weight: 600;
       font-size: 1.2rem;
@@ -344,50 +341,64 @@
     padding-bottom: 0.25rem;
   }
 
-  .top_five_issue {
+  .top_five_issue_row {
+    --row-font-size: calc(16rem / var(--base-font-size));
+    @media (min-width: 40rem) {
+      --row-font-size: calc(18rem / var(--base-font-size));
+    }
+    font-size: var(--row-font-size);
     display: flex;
+    align-items: flex-start;
     justify-content: space-between;
-    font-size: calc(16rem / var(--base-font-size));
 
     button {
       background: #efefef;
     }
 
     a {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
       color: black;
       text-decoration: none;
       margin-right: 0.5rem;
       text-underline-offset: .1rem;
       line-height: 1.1;
-      margin-top: auto;
-      margin-bottom: auto;
-
-      @supports (-webkit-line-clamp: 2) {
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        white-space: initial;
-      }
+      transition: max-height 0.5s ease;
+      max-height: 40rem;
+      overflow: hidden;
 
       &:hover,
       &:focus {
         color: var(--c-dark);
         text-decoration: underline;
       }
+    }
+
+    a.short {
+      max-height: calc(1.1 * var(--row-font-size));
+
+      @supports (-webkit-line-clamp: 2) {
+        max-height: calc(2 * 1.1 * var(--row-font-size));
+      }
+    }
+
+    a.truncated {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      transition: max-height 0.5s ease;
+      max-height: calc(1.1 * var(--row-font-size));
+
+      @supports (-webkit-line-clamp: 2) {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        white-space: initial;
+        max-height: calc(2 * 1.1 * var(--row-font-size));
+      }
 
       @media (min-width: 40rem) {
         line-height: initial;
         white-space: nowrap;
-      }
-    }
 
-    @media (min-width: 40rem) {
-      font-size: calc(18rem / var(--base-font-size));
-
-      a {
         @supports (-webkit-line-clamp: 2) {
           display: block;
           white-space: nowrap;
@@ -414,6 +425,34 @@
     @media (min-width: 40rem) {
       max-width: 552px;
       width: 552px;
+    }
+
+    .row_detail {
+      overflow: hidden;
+      max-height: 0;
+      transition: max-height 0.5s ease;
+      font-size: calc(16rem / var(--base-font-size));
+      @media (min-width: 40rem) {
+        font-size: calc(18rem / var(--base-font-size));
+      }
+
+      a {
+        text-decoration: none;
+        text-underline-offset: .1rem;
+        line-height: 1.1;
+        font-weight: bold;
+
+        &:hover,
+        &:focus {
+          color: var(--c-dark);
+          text-decoration: underline;
+        }
+      }
+    }
+
+    .row_detail.expanded {
+      transition: max-height 0.5s ease;
+      max-height: 50rem; /* must be larger than the tallest possible content */
     }
   }
 
@@ -468,7 +507,6 @@
     .issue_name,
     .issue_long_name {
       text-align: left;
-      font-size: calc(16rem / var(--base-font-size));
     }
 
     .issue_name {

--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -356,6 +356,33 @@
       background: #efefef;
     }
 
+    button.issue_name {
+      background: none;
+      border: none;
+      padding: 0;
+      display: inline;
+      text-align: start;
+      white-space: initial;
+
+      &::before {
+        content: "";
+        display: inline-block;
+        width: 0;
+        height: 0;
+        border-top: .5rem solid var(--c-base);
+        border-right: .3rem solid transparent;
+        border-bottom: 0;
+        border-left: .3rem solid transparent;
+        margin-right: .5rem;
+        transform: rotate(120deg) translate(-.25rem);
+        transition: transform 0.5s ease;
+      }
+
+      &:hover::before {
+        border-top: .5rem solid var(--c-blue);
+      }
+    }
+
     a, button.issue_name {
       color: black;
       text-decoration: none;
@@ -367,12 +394,6 @@
       max-height: 40rem;
       min-height: initial;
       overflow: hidden;
-      background: none;
-      border: none;
-      padding: 0;
-      display: inline;
-      text-align: start;
-      white-space: initial;
 
       &:hover,
       &:focus {
@@ -392,6 +413,10 @@
 
       @media (min-width: 40rem) {
         max-height: calc(var(--row-line-height) * var(--row-font-size));
+      }
+
+      &::before {
+        transform: rotate(30deg);
       }
     }
 
@@ -415,6 +440,10 @@
         white-space: nowrap;
         display: block;
         max-height: calc(var(--row-line-height) * var(--row-font-size));
+      }
+
+      &::before {
+        transform: rotate(30deg);
       }
     }
   }
@@ -440,9 +469,10 @@
     }
 
     .row_detail {
+      padding-top: .2rem;
       overflow: hidden;
       max-height: 0;
-      transition: max-height 0.5s ease;
+      transition: max-height .5s ease;
       font-size: calc(16rem / var(--base-font-size));
       @media (min-width: 40rem) {
         font-size: calc(18rem / var(--base-font-size));
@@ -463,7 +493,6 @@
     }
 
     .row_detail.expanded {
-      transition: max-height 0.5s ease;
       overflow: visible;
       max-height: 50rem; /* must be larger than the tallest possible content */
     }

--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -89,7 +89,7 @@
 
   h2 {
     text-align: start;
-    margin: .6rem 0 0.2rem;
+    margin: 0.6rem 0 0.2rem;
     font-weight: normal;
     font-size: calc(20rem / var(--base-font-size));
     color: #000;
@@ -142,7 +142,7 @@
 
   .subtitle_detail {
     padding: 0 1rem 0;
-    margin: .6rem 0 0;
+    margin: 0.6rem 0 0;
 
     @media (min-width: 40rem) {
       padding: 0.5rem 1.5rem 0;
@@ -196,7 +196,7 @@
     color: #555;
     appearance: base-select;
     line-height: 1;
-  
+
     :hover,
     :focus {
       background: #ddd;
@@ -369,25 +369,26 @@
         display: inline-block;
         width: 0;
         height: 0;
-        border-top: .5rem solid var(--c-base);
-        border-right: .3rem solid transparent;
+        border-top: 0.5rem solid var(--c-base);
+        border-right: 0.3rem solid transparent;
         border-bottom: 0;
-        border-left: .3rem solid transparent;
-        margin-right: .5rem;
-        transform: rotate(120deg) translate(-.25rem);
+        border-left: 0.3rem solid transparent;
+        margin-right: 0.5rem;
+        transform: rotate(120deg) translate(-0.25rem);
         transition: transform 0.5s ease;
       }
 
       &:hover::before {
-        border-top: .5rem solid var(--c-dark);
+        border-top: 0.5rem solid var(--c-dark);
       }
     }
 
-    a, button.issue_name {
+    a,
+    button.issue_name {
       color: black;
       text-decoration: none;
       margin-right: 0.5rem;
-      text-underline-offset: .1rem;
+      text-underline-offset: 0.1rem;
       font-size: var(--row-font-size);
       line-height: var(--row-line-height);
       transition: max-height 0.5s ease;
@@ -471,19 +472,19 @@
     .row_detail {
       overflow: hidden;
       max-height: 0;
-      transition: max-height .5s ease;
+      transition: max-height 0.5s ease;
       font-size: calc(16rem / var(--base-font-size));
       @media (min-width: 40rem) {
         font-size: calc(18rem / var(--base-font-size));
       }
 
       div {
-        padding-top: .2rem;
+        padding-top: 0.2rem;
       }
 
       a {
         text-decoration: none;
-        text-underline-offset: .1rem;
+        text-underline-offset: 0.1rem;
         line-height: var(--row-line-height);
         font-weight: bold;
 
@@ -574,7 +575,8 @@
     }
   }
 
-  #state_map_label, #dot_label {
+  #state_map_label,
+  #dot_label {
     filter: drop-shadow(0.125rem 0.125rem 0.25rem #888c);
     z-index: 10;
     background: #fff;
@@ -590,7 +592,7 @@
   .leftLabel:after,
   .rightLabel:after,
   .topLabel:after {
-    content: '';
+    content: "";
     position: absolute;
     width: 0;
     height: 0;
@@ -670,17 +672,27 @@
     fill: #fff;
   }
 
-  .results_vm { color: #6a51a3; font-weight: bold; }
-  .results_contact { color: #807dba; font-weight: bold; }
-  .results_unavailable { color: #4a1486; font-weight: bold; }
+  .results_vm {
+    color: #6a51a3;
+    font-weight: bold;
+  }
+  .results_contact {
+    color: #807dba;
+    font-weight: bold;
+  }
+  .results_unavailable {
+    color: #4a1486;
+    font-weight: bold;
+  }
 
   .i-bar-location {
     color: #000;
     background: #fff;
     border-top: 0;
 
-    a, .button-link {
-      color: rgba(0,0,0,0.9);
+    a,
+    .button-link {
+      color: rgba(0, 0, 0, 0.9);
     }
 
     form input {
@@ -700,21 +712,33 @@
 }
 
 @keyframes loaderBounce {
-  from { transform: scale(1); opacity: 0.6; }
-  to { transform: scale(1.4); opacity: 1; }
+  from {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  to {
+    transform: scale(1.4);
+    opacity: 1;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  #loader { animation: loaderFade 1.5s infinite alternate; }
+  #loader {
+    animation: loaderFade 1.5s infinite alternate;
+  }
 
   @keyframes loaderFade {
-    from { opacity: 0.4; }
-    to { opacity: 1; }
+    from {
+      opacity: 0.4;
+    }
+    to {
+      opacity: 1;
+    }
   }
 }
 
 #dashboard_title {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   line-height: 1;
 
   @media (min-width: 40rem) {

--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -375,7 +375,7 @@
         border-left: 0.3rem solid transparent;
         margin-right: 0.5rem;
         transform: rotate(120deg) translate(-0.25rem);
-        transition: transform 0.5s ease;
+        transition: transform 0.5s ease-in-out;
       }
 
       &:hover::before {
@@ -391,7 +391,7 @@
       text-underline-offset: 0.1rem;
       font-size: var(--row-font-size);
       line-height: var(--row-line-height);
-      transition: max-height 0.5s ease;
+      transition: max-height 0.5s ease-out;
       max-height: 40rem;
       min-height: initial;
       overflow: hidden;
@@ -425,7 +425,7 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      transition: max-height 0.5s ease;
+      transition: max-height 0.5s ease-out;
       max-height: calc(var(--row-line-height) * var(--row-font-size));
 
       @supports (-webkit-line-clamp: 2) {
@@ -472,7 +472,7 @@
     .row_detail {
       overflow: hidden;
       max-height: 0;
-      transition: max-height 0.5s ease;
+      transition: max-height 0.5s ease-out;
       font-size: calc(16rem / var(--base-font-size));
       @media (min-width: 40rem) {
         font-size: calc(18rem / var(--base-font-size));
@@ -497,8 +497,8 @@
     }
 
     .row_detail.expanded {
-      overflow: visible;
-      max-height: 50rem; /* must be larger than the tallest possible content */
+      transition: max-height 0.5s ease-out;
+      max-height: calc(16rem * 5 / var(--base-font-size)); /* must be larger than the tallest possible content, but shorter means a better transition */
     }
   }
 

--- a/assets/sass/_dashboard.scss
+++ b/assets/sass/_dashboard.scss
@@ -379,7 +379,7 @@
       }
 
       &:hover::before {
-        border-top: .5rem solid var(--c-blue);
+        border-top: .5rem solid var(--c-dark);
       }
     }
 
@@ -469,13 +469,16 @@
     }
 
     .row_detail {
-      padding-top: .2rem;
       overflow: hidden;
       max-height: 0;
       transition: max-height .5s ease;
       font-size: calc(16rem / var(--base-font-size));
       @media (min-width: 40rem) {
         font-size: calc(18rem / var(--base-font-size));
+      }
+
+      div {
+        padding-top: .2rem;
       }
 
       a {

--- a/layouts/dashboard/section.html
+++ b/layouts/dashboard/section.html
@@ -53,11 +53,13 @@
           </div>
 
           <div class="overlayBox" id="state_map_key_box">
-            <div class="title">Top Issues Nationwide</div>
+            <div class="title" aria-describedby="state_footnote">Top issue per state*</div>
             <ol id="state_map_key">
             </ol>
           </div>
         </div>
+
+        <div id="state_footnote" class="footnote">* Includes other US jurisdictions such as D.C., Puerto Rico, etc.</div>
       </div>
     
       <div>

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -170,7 +170,7 @@ const drawStateResults = (
     'ol#top_five_state_holder',
     stateResults.issueCounts,
     stateResults.id,
-    ` in ${stateResults.name}`,
+    `${stateResults.name}'s`,
     duration,
     issueColor,
     stateResults.total,
@@ -190,7 +190,7 @@ const drawUsaPane = (
     'ol#top_five_all_holder',
     topIssues,
     'usa',
-    ' across the nation',
+    'nationwide',
     duration,
     issueColor,
     usaData.usa.total,
@@ -227,41 +227,85 @@ const drawTopFiveIssues = (
       'title',
       (d: IssueCountData) =>
         `${((d.count / total) * 100).toFixed(1)}% of calls: ${d.name}`
-  );
-  const issueSection = rowContent.append('div')
-      .attr('class', 'top_five_issue_row')
-      .attr('id', (d: IssueCountData) => `issue_row_${sectionId}_${d.issue_id}`);
+    );
+  const issueSection = rowContent
+    .append('div')
+    .attr('class', 'top_five_issue_row')
+    .attr('id', (d: IssueCountData) => `issue_row_${sectionId}_${d.issue_id}`);
 
   const collapseIssueRow = (event: Event, d: IssueCountData) => {
+    if (event instanceof KeyboardEvent) {
+      if (
+        (event.key === ' ' || event.key === 'Enter') &&
+        event.target === this
+      ) {
+        event.preventDefault();
+      } else {
+        return;
+      }
+    }
     const row = d3.select(`li#top_five_${sectionId}_${d.issue_id}`);
-    row.select('a').on('click', null).classed('short', true).transition().delay(500).attr('class', 'issue_name truncated').on('end', () => {
-      row.on('click', expandIssueRow);
-    });
+    row
+      .select('button.issue_name')
+      .on('click', null)
+      .on('keydown', null)
+      .classed('short', true)
+      .transition()
+      .delay(500)
+      .attr('class', 'issue_name truncated')
+      .on('end', () => {
+        row.select('div.row_detail').attr('hidden', true);
+        row.on('click', expandIssueRow).on('keydown', expandIssueRow);
+      });
     row.select('div.row_detail').classed('expanded', false);
     event.stopPropagation();
   };
 
   const expandIssueRow = (event: Event, d: IssueCountData) => {
+    if (event instanceof KeyboardEvent) {
+      if (
+        (event.key === ' ' || event.key === 'Enter') &&
+        event.target === this
+      ) {
+        event.preventDefault();
+      } else {
+        return;
+      }
+    }
     const row = d3.select(`li#top_five_${sectionId}_${d.issue_id}`);
-    row.select('a').classed('truncated', false).on('click', collapseIssueRow);
-    row.select('div.row_detail').classed('expanded', true);
+    row
+      .select('button.issue_name')
+      .classed('truncated', false)
+      .on('click', collapseIssueRow)
+      .on('keydown', collapseIssueRow);
+    row.select('div.row_detail').attr('hidden', null).classed('expanded', true);
     event.stopPropagation();
   };
 
-  const rowDetails = rowContent.append('div').classed('row_detail', true);
-  rowDetails.append('div').html((d: IssueCountData) => `${d.count} calls ${countTextModifier}, ${duration}`);
-  rowDetails.append('div').html((d: IssueCountData) => `1234 calls nationwide, ${duration}`); // TODO: Nationwide total in 7 days
-  rowDetails.append('a')
+  const rowDetails = rowContent
+    .append('div')
+    .classed('row_detail', true)
+    .attr('hidden', true);
+  rowDetails
+    .append('div')
+    .html(
+      (d: IssueCountData) =>
+        `${((d.count / total) * 100).toFixed(1)}% of ${countTextModifier} calls in the ${duration}`
+    );
+  // rowDetails.append('div').html((d: IssueCountData) => `1234 calls nationwide, ${duration}`); // TODO: Nationwide total in 7 days
+  rowDetails
+    .append('a')
     .attr('target', '_blank')
     .attr('href', (d: IssueCountData) => `/issue/${d.slug}`)
     .html('Make this call'); // TODO: Show a different text / link if it is archived.
 
   issueSection
-    .append('a')
+    .append('button')
     .classed('issue_name', true)
     .classed('truncated', true)
     .html((d: IssueCountData) => `${d.name}`)
-    .on('click', expandIssueRow);
+    .on('click', expandIssueRow)
+    .on('keydown', expandIssueRow);
 
   // TODO: Show as text instead of button if not enough beeswarm.
   let stat;
@@ -723,7 +767,7 @@ const drawRepsPane = (
     topFiveHolderSelector,
     repData.topIssues,
     repData.id,
-    ` to ${repData.repInfo.name}`,
+    `${repData.repInfo.name}'s`,
     duration,
     issueColor,
     repData.total,
@@ -837,14 +881,15 @@ const drawRepsPane = (
     const onIssueSelected = function (event: Event, d: IssueCountData) {
       if (event instanceof KeyboardEvent) {
         if (
-          (event.key === ' ' || event.key === 'Enter') && event.target === this) {
+          (event.key === ' ' || event.key === 'Enter') &&
+          event.target === this
+        ) {
           event.preventDefault();
         } else {
           return;
         }
       } else if (event.target === this) {
         event.stopPropagation();
-        
       }
       if (selectedIssueId === d.issue_id) {
         repData.beeswarm.forEach((b) => (b.data.selected = false));
@@ -875,7 +920,7 @@ const drawRepsPane = (
         );
         // Ensure everything else is deselected visually.
         d3.select(topFiveHolderSelector)
-          .selectAll('button')
+          .selectAll('button.stat')
           .classed('selected', false)
           .style('background-color', null)
           .style('color', (i) => issueColor(i.issue_id))
@@ -908,7 +953,9 @@ const drawRepsPane = (
 
     // Only show beeswarm if there's enough calls.
     let selectedIssueId: number | null = repData.topIssues[0].issue_id;
-    const showCallsBtns = d3.select(topFiveHolderSelector).selectAll('button');
+    const showCallsBtns = d3
+      .select(topFiveHolderSelector)
+      .selectAll('button.stat');
     showCallsBtns
       .on('pointerover', function (_: Event, d: IssueCountData) {
         if (selectedIssueId !== d.issue_id) {

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -255,9 +255,10 @@ const drawTopFiveIssues = (
       .delay(500)
       .attr('class', 'issue_name truncated')
       .on('end', () => {
-        row.select('div.row_detail')
-            .style('visibility', 'visible')
-            .attr('aria-hidden', true);
+        row
+          .select('div.row_detail')
+          .style('visibility', 'visible')
+          .attr('aria-hidden', true);
         row.on('click', expandIssueRow).on('keydown', expandIssueRow);
       });
     row.select('div.row_detail').classed('expanded', null);
@@ -282,7 +283,8 @@ const drawTopFiveIssues = (
       .attr('aria-expanded', true)
       .on('click', collapseIssueRow)
       .on('keydown', collapseIssueRow);
-    row.select('div.row_detail')
+    row
+      .select('div.row_detail')
       .attr('aria-hidden', false)
       .style('visibility', 'visible')
       .classed('expanded', true);

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -460,7 +460,7 @@ const drawUsaMap = (
       .style('border-color', (d: IssueCountData) => issueColor(d.issue_id))
       .html(
         (d: IssueCountData) =>
-          `<b>${d.count} jurisdiction${d.count == 1 ? '' : 's'}</b>: ${d.name}`
+          `<b>${d.count} state${d.count == 1 ? '' : 's'}</b>: ${d.name}`
       );
 
     let selectedState: string | null = null;

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -255,10 +255,12 @@ const drawTopFiveIssues = (
       .delay(500)
       .attr('class', 'issue_name truncated')
       .on('end', () => {
-        row.select('div.row_detail').attr('hidden', true);
+        row.select('div.row_detail')
+            .style('visibility', 'visible')
+            .attr('aria-hidden', true);
         row.on('click', expandIssueRow).on('keydown', expandIssueRow);
       });
-    row.select('div.row_detail').classed('expanded', false);
+    row.select('div.row_detail').classed('expanded', null);
     event.stopPropagation();
   };
 
@@ -280,14 +282,19 @@ const drawTopFiveIssues = (
       .attr('aria-expanded', true)
       .on('click', collapseIssueRow)
       .on('keydown', collapseIssueRow);
-    row.select('div.row_detail').attr('hidden', null).classed('expanded', true);
+    row.select('div.row_detail')
+      .attr('aria-hidden', false)
+      .style('visibility', 'visible')
+      .classed('expanded', true);
     event.stopPropagation();
   };
 
   const rowDetails = rowContent
     .append('div')
     .classed('row_detail', true)
-    .attr('hidden', true);
+    .attr('aria-hidden', true)
+    .style('visibility', 'hidden');
+
   rowDetails
     .append('div')
     .html(

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -294,12 +294,14 @@ const drawTopFiveIssues = (
       (d: IssueCountData) =>
         `${((d.count / total) * 100).toFixed(1)}% of ${countTextModifier} calls in the ${duration}`
     );
-  // rowDetails.append('div').html((d: IssueCountData) => `1234 calls nationwide, ${duration}`); // TODO: Nationwide total in 7 days
-  rowDetails
-    .append('a')
-    .attr('target', '_blank')
-    .attr('href', (d: IssueCountData) => `/issue/${d.slug}`)
-    .html('Make this call'); // TODO: Show a different text / link if it is archived.
+  rowDetails.append('div').html((d: IssueCountData) => {
+    if (d.archived) {
+      // TODO: Add a link to the archive when possible.
+      return 'This call is no longer active.';
+    } else {
+      return `<a target="_blank" href="/issue/${d.slug}">Make this call</a>`;
+    }
+  });
 
   issueSection
     .append('button')
@@ -760,7 +762,7 @@ const drawRepsPane = (
     .html(() => {
       let text = ''; //`The most-called issues for ${repData.repInfo.name} ${duration} from 5 Calls.`;
       if (repData.total >= MIN_FOR_BEESWARM) {
-        text += ' Select a call counts to see it highlighted below.';
+        text += ' Select a call count to see it highlighted below.';
       }
       return text;
     });

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -250,6 +250,7 @@ const drawTopFiveIssues = (
       .on('click', null)
       .on('keydown', null)
       .classed('short', true)
+      .attr('aria-expanded', false)
       .transition()
       .delay(500)
       .attr('class', 'issue_name truncated')
@@ -276,6 +277,7 @@ const drawTopFiveIssues = (
     row
       .select('button.issue_name')
       .classed('truncated', false)
+      .attr('aria-expanded', true)
       .on('click', collapseIssueRow)
       .on('keydown', collapseIssueRow);
     row.select('div.row_detail').attr('hidden', null).classed('expanded', true);
@@ -303,6 +305,7 @@ const drawTopFiveIssues = (
     .append('button')
     .classed('issue_name', true)
     .classed('truncated', true)
+    .attr('aria-expanded', false)
     .html((d: IssueCountData) => `${d.name}`)
     .on('click', expandIssueRow)
     .on('keydown', expandIssueRow);

--- a/react/src/utils/api.ts
+++ b/react/src/utils/api.ts
@@ -87,6 +87,7 @@ export interface IssueCountData {
   name: string;
   slug: string;
   count: number;
+  archived: boolean;
 }
 
 export interface RegionSummaryData {


### PR DESCRIPTION
More contents can be held in these sections. For now, just contains a link to make a call and the percentage of calls it represents in the past week.

Turns the issue name from a link to the issue page into a button that expands/collapses the section; styles the button the same as the link was styled before.