### PR TITLE
Issue #109

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,8 +1,0 @@
-{{ define "bodyclass" }}home{{ end }} {{ define "main" }}
-<div class="content">
-  <h4 class="notfound-note">
-    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>Looks like you reached a page that doesn't exist. 
-    <a href="/">Head back to the front page</a> to see current topics to call on.
-  </h4>
-</div>
-{{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,8 @@
+{{ define "bodyclass" }}home{{ end }} {{ define "main" }}
+<div class="content">
+  <h4 class="notfound-note">
+    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>Looks like you reached a page that doesn't exist. 
+    <a href="/">Head back to the front page</a> to see current topics to call on.
+  </h4>
+</div>
+{{ end }}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,3 +1,9 @@
+{{ define "bodyclass" }} home {{ end }}
 {{ define "main" }}
-this isn't used but needs to be here for sections to work, I guess.
+<div class="content">
+    <h4 class="notfound-note">
+        <i class="fas fa-exclamation-circle" aria-hidden="true"></i>Looks like you reached a page that doesn't exist.
+        <a href="/">Head back to the front page</a> to see current topics to call on.
+    </h4>
+</div>
 {{ end }}


### PR DESCRIPTION
moved the 404 layout to the default directory. any attempted navigation to a non-existent page will now properly display the updated 404 page

before:
<img width="952" height="284" alt="before" src="https://github.com/user-attachments/assets/747bd04c-064d-4a0b-8499-05b1845cd094" />

after:
<img width="952" height="284" alt="after" src="https://github.com/user-attachments/assets/942939d1-e49c-465d-975c-f3081837d6a4" />

