### PR TITLE
Handle local reps data load fail with error message

### DIFF
--- a/layouts/dashboard/section.html
+++ b/layouts/dashboard/section.html
@@ -102,6 +102,12 @@
            </div>
          </div>
        </div>
+       <div id="location_error" hidden>
+        <div>
+          <h3>Error loading your representatives' call data</h3>
+          <p>Please try again later</p>
+        </div>
+       </div>
     </div>
   </div>
 

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -170,7 +170,9 @@ const drawUsaPane = (
   issueColor: d3.ScaleOrdinal<number, string>,
   duration: string
 ) => {
-  const topIssues = usaData.usa.issueCounts ? usaData.usa.issueCounts.slice(0, 5) : [];
+  const topIssues = usaData.usa.issueCounts
+    ? usaData.usa.issueCounts.slice(0, 5)
+    : [];
   d3.selectAll('div#total_all').html(usaData.usa.total.toLocaleString());
   drawTopFiveIssues(
     'ol#top_five_all_holder',
@@ -1613,7 +1615,7 @@ class Dashboard extends React.Component<null, State> {
       }
     }
     return localStorage.getItem(Constants.LOCAL_STORAGE_KEYS.DISTRICT);
-  }
+  };
 
   async requestDashboardData() {
     let districtId = this.getDistrictId();

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -1668,7 +1668,12 @@ class Dashboard extends React.Component<null, State> {
     }
 
     const usaData = this.state.usaData;
-    if (this.state.isError || this.state.usaData.states.length == 0) {
+    if (
+      this.state.isError ||
+      usaData.states.length == 0 ||
+      usaData.usa === null ||
+      usaData.usa.total == 0
+    ) {
       // Happens if the data isn't populated properly (like after an outage).
       return (
         <div>

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -170,7 +170,7 @@ const drawUsaPane = (
   issueColor: d3.ScaleOrdinal<number, string>,
   duration: string
 ) => {
-  const topIssues = usaData.usa.issueCounts.slice(0, 5);
+  const topIssues = usaData.usa.issueCounts ? usaData.usa.issueCounts.slice(0, 5) : [];
   d3.selectAll('div#total_all').html(usaData.usa.total.toLocaleString());
   drawTopFiveIssues(
     'ol#top_five_all_holder',

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -1602,19 +1602,21 @@ class Dashboard extends React.Component<null, State> {
     });
   }
 
-  async requestDashboardData() {
+  getDistrictId = () => {
     const urlParams = new URLSearchParams(window.location.search);
-    let districtId = localStorage.getItem(
-      Constants.LOCAL_STORAGE_KEYS.DISTRICT
-    );
     if (urlParams.has(Constants.LOCAL_STORAGE_KEYS.DISTRICT)) {
       // Override from URL parameter if present.
       const urlDistrict = urlParams.get(Constants.LOCAL_STORAGE_KEYS.DISTRICT);
       // Validate length, although not the actual code.
       if (urlDistrict && (urlDistrict.length == 4 || urlDistrict.length == 5)) {
-        districtId = urlDistrict;
+        return urlDistrict;
       }
     }
+    return localStorage.getItem(Constants.LOCAL_STORAGE_KEYS.DISTRICT);
+  }
+
+  async requestDashboardData() {
+    let districtId = this.getDistrictId();
 
     let usaSummaryData = null;
     let repsSummaryData = null;
@@ -1638,6 +1640,7 @@ class Dashboard extends React.Component<null, State> {
         isLoading: false,
         isError: true
       });
+      // USA summary data required to show dashboard.
       return;
     }
     const repsData = processRepsData(repsSummaryData);
@@ -1780,6 +1783,8 @@ class Dashboard extends React.Component<null, State> {
             'display',
             null
           );
+        } else if (district && district.length > 0) {
+          document.getElementById('location_error')!.removeAttribute('hidden');
         } else {
           document.getElementById('location_picker')!.removeAttribute('hidden');
         }

--- a/react/src/utils/dashboardData.ts
+++ b/react/src/utils/dashboardData.ts
@@ -187,6 +187,9 @@ export function getTopIssueData(usaData: UsaSummaryData): {
   topIssueIds: number[];
   issueIdToName: { [key: number]: string };
 } {
+  if (!usaData.usa.issueCounts) {
+    return {topIssueIds: [], issueIdToName: {}};
+  }
   const topIssueIds: number[] = usaData.usa.issueCounts.reduce((agg, row) => {
     agg.push(row.issue_id);
     return agg;

--- a/react/src/utils/dashboardData.ts
+++ b/react/src/utils/dashboardData.ts
@@ -188,7 +188,7 @@ export function getTopIssueData(usaData: UsaSummaryData): {
   issueIdToName: { [key: number]: string };
 } {
   if (!usaData.usa.issueCounts) {
-    return {topIssueIds: [], issueIdToName: {}};
+    return { topIssueIds: [], issueIdToName: {} };
   }
   const topIssueIds: number[] = usaData.usa.issueCounts.reduce((agg, row) => {
     agg.push(row.issue_id);


### PR DESCRIPTION
Instead of showing the "set your location" card in the case of a location being present but the reps local data missing, we can show an error message under the reps tab (see screenshot)

Test: Executed with no location set in local storage or the URL and got the location picker, or with a location in localstorage but no response from the server and got the new error

<img width="603" height="439" alt="image" src="https://github.com/user-attachments/assets/268c922a-8583-4f32-a522-58a337c19910" />
