### PR TITLE
Fix an issue with clicking states in Chrome; don't render beeswarm if > 6000 calls for a rep; add scaled counts map

### DIFF
--- a/layouts/dashboard/section.html
+++ b/layouts/dashboard/section.html
@@ -34,7 +34,9 @@
         <div role="tablist" class="tab_container">
           <button id="tab_top_calls" role="tab" aria-selected="true" 
               aria-controls="state_map_section" tabindex="0" class="selected">Top issues</button>
-          <button id="tab_total_calls" role="tab" aria-selected="true" 
+          <button id="tab_scaled_calls" role="tab" aria-selected="false" 
+              aria-controls="state_map_section" tabindex="-1">Call volumes</button>
+          <button id="tab_total_calls" role="tab" aria-selected="false" 
               aria-controls="state_map_section" tabindex="-1">Total calls</button>
         </div>
         <div id="state_map_section" role="tabpanel" aria-labelledby="tab_top_calls">
@@ -67,6 +69,7 @@
 
           <div id="state_footnote" class="footnote">
             * Includes other US jurisdictions such as D.C., Puerto Rico, etc.
+            <span id="state_footnote_scaled">Population data from <a href="https://www.census.gov/programs-surveys/popest/data/tables.html">census.gov</a>, 2025.</span>
           </div>
         </div>
       </div>

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -801,7 +801,7 @@ const drawUsaMap = (
         }
         // Track the state over which the pointer went down. If the pointer
         // goes up on the same state it went down on, that's a click.
-        let pointerDownState : string = '';
+        let pointerDownState: string = '';
         d3.select(this)
           .on('pointerover', function (event: Event, d) {
             if (selectedState === d.id) {
@@ -818,7 +818,7 @@ const drawUsaMap = (
               );
             }
           })
-          .on('pointerdown', function(event: Event, d: Feature) {
+          .on('pointerdown', function (event: Event, d: Feature) {
             pointerDownState = d.id;
           })
           .on('pointerup', function (event: Event, d: Feature) {
@@ -827,7 +827,7 @@ const drawUsaMap = (
             }
             pointerDownState = '';
           })
-          .on('pointerout', function(event: Event, d: Feature) {
+          .on('pointerout', function (event: Event, d: Feature) {
             const state = d3.select(this);
             if (selectedState !== d.id) {
               state.transition().attr('stroke', '#fff').attr('stroke-width', 1);

--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -799,6 +799,9 @@ const drawUsaMap = (
         if (initialState !== null) {
           selectState(initialState);
         }
+        // Track the state over which the pointer went down. If the pointer
+        // goes up on the same state it went down on, that's a click.
+        let pointerDownState : string = '';
         d3.select(this)
           .on('pointerover', function (event: Event, d) {
             if (selectedState === d.id) {
@@ -815,10 +818,16 @@ const drawUsaMap = (
               );
             }
           })
-          .on('click', function (event: Event, d: Feature) {
-            selectState(d.id);
+          .on('pointerdown', function(event: Event, d: Feature) {
+            pointerDownState = d.id;
           })
-          .on('pointerout', function (event: Event, d: Feature) {
+          .on('pointerup', function (event: Event, d: Feature) {
+            if (pointerDownState === d.id) {
+              selectState(d.id);
+            }
+            pointerDownState = '';
+          })
+          .on('pointerout', function(event: Event, d: Feature) {
             const state = d3.select(this);
             if (selectedState !== d.id) {
               state.transition().attr('stroke', '#fff').attr('stroke-width', 1);
@@ -858,9 +867,8 @@ const drawUsaMap = (
   });
 };
 
-const inBeeswarmRange = (count: number) : boolean => {
- return count >= MIN_FOR_BEESWARM &&
-        count <= MAX_FOR_BEESWARM
+const inBeeswarmRange = (count: number): boolean => {
+  return count >= MIN_FOR_BEESWARM && count <= MAX_FOR_BEESWARM;
 };
 
 const drawRepsPane = (
@@ -1234,10 +1242,7 @@ const drawBeeswarm = (
   const description = parentDiv
     .append('div')
     .attr('class', 'description')
-    .attr(
-      'hidden',
-      !inBeeswarmRange(repData.total) ? true : null
-    );
+    .attr('hidden', !inBeeswarmRange(repData.total) ? true : null);
 
   description
     .append('h2')

--- a/react/src/utils/dashboardData.test.ts
+++ b/react/src/utils/dashboardData.test.ts
@@ -66,7 +66,7 @@ describe('processRepsData', () => {
   });
 
   it('should not expand when too many calls', () => {
-const repsSummaryData: RepsSummaryData = {
+    const repsSummaryData: RepsSummaryData = {
       reps: [
         {
           id: 'rep1',

--- a/react/src/utils/dashboardData.test.ts
+++ b/react/src/utils/dashboardData.test.ts
@@ -9,7 +9,7 @@ import { UserContactEventType } from '../common/models/contactEvent';
 
 describe('processRepsData', () => {
   it('should return an empty array when given null', () => {
-    const result = processRepsData(null);
+    const result = processRepsData(null, /* maxForBeeswarm= */ 50);
     expect(result).toEqual([]);
   });
 
@@ -47,7 +47,7 @@ describe('processRepsData', () => {
       ]
     };
 
-    const result = processRepsData(repsSummaryData);
+    const result = processRepsData(repsSummaryData, /* maxForBeeswarm= */ 50);
 
     expect(result.length).toBe(1);
     const repData = result[0];
@@ -80,7 +80,7 @@ describe('processRepsData', () => {
       repsData: []
     };
 
-    const result = processRepsData(repsSummaryData);
+    const result = processRepsData(repsSummaryData, /* maxForBeeswarm= */ 50);
 
     expect(result.length).toBe(1);
     const repData = result[0];
@@ -115,7 +115,7 @@ describe('processRepsData', () => {
       ]
     };
 
-    const result = processRepsData(repsSummaryData);
+    const result = processRepsData(repsSummaryData, /* maxForBeeswarm= */ 50);
 
     expect(result.length).toBe(1);
     const repData = result[0];
@@ -150,7 +150,7 @@ describe('processRepsData', () => {
       ]
     };
 
-    const result = processRepsData(repsSummaryData);
+    const result = processRepsData(repsSummaryData, /* maxForBeeswarm= */ 50);
 
     expect(result.length).toBe(1);
     const repData = result[0];
@@ -167,7 +167,7 @@ describe('processRepsData', () => {
       repsData: []
     };
 
-    const result = processRepsData(repsSummaryData);
+    const result = processRepsData(repsSummaryData, /* maxForBeeswarm= */ 50);
 
     expect(result).toEqual([]);
   });

--- a/react/src/utils/dashboardData.test.ts
+++ b/react/src/utils/dashboardData.test.ts
@@ -1,4 +1,5 @@
 import {
+  getPopulation,
   getTopIssueData,
   getUsaMapKeyData,
   processRepsData
@@ -62,6 +63,57 @@ describe('processRepsData', () => {
     expect(repData.callResults.filter((c) => c.issue_id == 1).length).toBe(3);
     expect(repData.callResults.filter((c) => c.issue_id == 2).length).toBe(5);
     expect(repData.callResults.filter((c) => c.issue_id == 3).length).toBe(2);
+  });
+
+  it('should not expand when too many calls', () => {
+const repsSummaryData: RepsSummaryData = {
+      reps: [
+        {
+          id: 'rep1',
+          name: 'Test Rep 1',
+          party: 'independent',
+          phone: '123-456-7890',
+          photoURL: 'http://example.com/rep1.jpg',
+          area: 'US House',
+          state: 'CA'
+        }
+      ],
+      repsData: [
+        {
+          id: 'rep1',
+          total: 10,
+          outcomes: [
+            { result: UserContactEventType.VOICEMAIL, count: 5 },
+            { result: UserContactEventType.CONTACT, count: 3 },
+            { result: UserContactEventType.UNAVAILABLE, count: 2 }
+          ],
+          topIssues: [],
+          aggregatedResults: [
+            { issue_id: 1, count: 2, time: 1000 },
+            { issue_id: 2, count: 4, time: 1000 },
+            { issue_id: 1, count: 1, time: 1001 },
+            { issue_id: 2, count: 1, time: 1001 },
+            { issue_id: 3, count: 2, time: 1002 }
+          ]
+        }
+      ]
+    };
+
+    const result = processRepsData(repsSummaryData, /* maxForBeeswarm= */ 5);
+
+    expect(result.length).toBe(1);
+    const repData = result[0];
+    expect(repData.id).toBe('rep1');
+    expect(repData.total).toBe(10);
+    expect(repData.percentVM).toBe(0.5);
+    expect(repData.percentContact).toBe(0.3);
+    expect(repData.percentUnavailable).toBe(0.2);
+
+    // Check call results were not expanded.
+    expect(repData.callResults.length).toBe(5);
+    expect(repData.callResults.filter((c) => c.issue_id == 1).length).toBe(2);
+    expect(repData.callResults.filter((c) => c.issue_id == 2).length).toBe(2);
+    expect(repData.callResults.filter((c) => c.issue_id == 3).length).toBe(1);
   });
 
   it('should handle a rep with no call data', () => {
@@ -354,5 +406,25 @@ describe('getTopIssueData', () => {
       2: 'Issue 2',
       3: 'Issue 3'
     });
+  });
+});
+
+describe('getPopulation', () => {
+  it('should get state population by ID', () => {
+    expect(getPopulation('CA')).toEqual(39355309);
+
+    // Ensure we've got all the other jurisdictions.
+    expect(getPopulation('DC')).toBeGreaterThan(1);
+    expect(getPopulation('PR')).toBeGreaterThan(1);
+    expect(getPopulation('AS')).toBeGreaterThan(1);
+    expect(getPopulation('GU')).toBeGreaterThan(1);
+    expect(getPopulation('VI')).toBeGreaterThan(1);
+  });
+
+  it('should return 1 when ID is not matched', () => {
+    // Ignore console.warn output.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(getPopulation('CAT')).toBe(1);
+    warnSpy.mockRestore();
   });
 });

--- a/react/src/utils/dashboardData.ts
+++ b/react/src/utils/dashboardData.ts
@@ -64,7 +64,8 @@ export interface BeeswarmNode<T> extends d3.SimulationNodeDatum {
  * @returns An array of processed representative data.
  */
 export function processRepsData(
-  repsSummaryData: RepsSummaryData | null
+  repsSummaryData: RepsSummaryData | null,
+  maxForBeeswarm: number
 ): ExpandedRepData[] {
   if (!repsSummaryData) {
     return [];
@@ -97,7 +98,9 @@ export function processRepsData(
         contactSummaryData.aggregatedResults as unknown as BeeswarmCallCount[];
 
       // In-place expand to individual calls.
-      expandRepResults(expandedResult.callResults);
+      if (expandedResult.total <= maxForBeeswarm) {
+        expandRepResults(expandedResult.callResults);
+      }
 
       // Calculate aggregated reachability stats.
       if (contactSummaryData.outcomes) {

--- a/react/src/utils/dashboardData.ts
+++ b/react/src/utils/dashboardData.ts
@@ -207,3 +207,72 @@ export function getTopIssueData(usaData: UsaSummaryData): {
     );
   return { topIssueIds, issueIdToName };
 }
+
+// 2025 population data from census.gov.
+const POPULATION_DATA: { [key: string]: number } = {
+  AS: 43268,
+  GU: 169691,
+  PR: 3184835,
+  VI: 103792,
+  AL: 5193088,
+  AK: 737270,
+  AZ: 7623818,
+  AR: 3114791,
+  CA: 39355309,
+  CO: 6012561,
+  CT: 3688496,
+  DE: 1059952,
+  DC: 693645,
+  FL: 23462518,
+  GA: 11302748,
+  HI: 1432820,
+  ID: 2029733,
+  IL: 12719141,
+  IN: 6973333,
+  IA: 3238387,
+  KS: 2977220,
+  KY: 4606864,
+  LA: 4618189,
+  ME: 1414874,
+  MD: 6265347,
+  MA: 7154084,
+  MI: 10127884,
+  MN: 5830405,
+  MS: 2954160,
+  MO: 6270541,
+  MT: 1144694,
+  NE: 2018006,
+  NV: 3282188,
+  NH: 1415342,
+  NJ: 9548215,
+  NM: 2125498,
+  NY: 20002427,
+  NC: 11197968,
+  ND: 799358,
+  OH: 11900510,
+  OK: 4123288,
+  OR: 4273586,
+  PA: 13059432,
+  RI: 1114521,
+  SC: 5570274,
+  SD: 935094,
+  TN: 7315076,
+  TX: 31709821,
+  UT: 3538904,
+  VT: 644663,
+  VA: 8880107,
+  WA: 8001020,
+  WV: 1766147,
+  WI: 5972787,
+  WY: 588753
+};
+
+// Safe getter for population data.
+export function getPopulation(id: string): number {
+  if (POPULATION_DATA[id]) {
+    return POPULATION_DATA[id];
+  }
+  console.warn('Could not find population data for ' + id);
+  // We will usually divide by population. Make sure to return something!
+  return 1;
+}


### PR DESCRIPTION
Some change in D3 or Chrome has caused clicking states on the map to stop working. Using pointerup works properly. Adds a bit more logic so the pointerdown and pointerup must be over the same state for the new state to be selected.

Caps the beeswarm plot at 6000 calls, which greatly speeds up the rendering of the reps pages, especially at higher call volumes. The plot isn't so useful at those volumes anyway. We can eventually replace with a line plot (fixes #116)

Add tab for calls scaled by population. Population data pulled from census.gov 2025 estimates. Tested with mouse & keyboard.