### PR TITLE
[Dashboard] Improvements to scaled calls

### DIFF
--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -17,7 +17,8 @@ import {
   getPopulation,
   getTopIssueData,
   getUsaMapKeyData,
-  processRepsData
+  processRepsData,
+  scaledCallsPerStateString
 } from '../utils/dashboardData';
 
 // Dashboard state.
@@ -562,13 +563,15 @@ const drawUsaMap = (
       }, 0) * SCALED_POP_DENOMINATOR;
     let scaledPopDenominator = SCALED_POP_DENOMINATOR;
     // If call counts are too low, scale up the denominator!
+    // It should be a multiple of 10.
     if (maxScaledTotal != 0) {
       while (maxScaledTotal < 10) {
         scaledPopDenominator *= 10;
         maxScaledTotal *= 10;
       }
     }
-    maxScaledTotal = Math.ceil(maxScaledTotal / 10) * 10;
+    // The maximum color on the scale is a round number: multiple of 5.
+    maxScaledTotal = Math.ceil(maxScaledTotal / 5) * 5;
     // Use colors linearly around `purple`
     const minScaledColor = '#d7d1de';
     const maxScaledColor = '#6319a8';
@@ -769,14 +772,14 @@ const drawUsaMap = (
           : 'Unknown';
         const state_results = statesResults.find((s) => s.id === selectedState);
         const total_calls = state_results ? state_results.total : 0;
-        const scaledCalls = Math.round(
-          (total_calls / getPopulation(selectedState)) * scaledPopDenominator
-        );
         drawStateLabel(
           state_node,
           state_name,
-          `${scaledCalls.toLocaleString()} call${scaledCalls == 1 ? '' : 's'} per ` +
-            `${scaledPopDenominator.toLocaleString()} people`,
+          scaledCallsPerStateString(
+            total_calls,
+            selectedState,
+            scaledPopDenominator
+          ),
           deselectState
         );
       }
@@ -805,16 +808,6 @@ const drawUsaMap = (
         }
       }
     };
-
-    d3.select('button#tab_top_calls')
-      .on('click', topCallPerStateClicked)
-      .on('keydown', handleMapTabEvent);
-    d3.select('button#tab_total_calls')
-      .on('click', totalCallsPerStateClicked)
-      .on('keydown', handleMapTabEvent);
-    d3.select('button#tab_scaled_calls')
-      .on('click', scaledCallsPerStateClicked)
-      .on('keydown', handleMapTabEvent);
 
     let selectedState: string | null = null;
     const width = 630;
@@ -915,13 +908,10 @@ const drawUsaMap = (
       } else if (
         d3.select('button#tab_scaled_calls').attr('aria-selected') == 'true'
       ) {
-        const scaledCalls = Math.round(
-          (total_calls / getPopulation(state)) * scaledPopDenominator
-        );
         drawStateLabel(
           state_node,
           state_name,
-          `${scaledCalls.toLocaleString()} calls per ${scaledPopDenominator.toLocaleString()} people`,
+          scaledCallsPerStateString(total_calls, state, scaledPopDenominator),
           deselectState
         );
       } else {
@@ -966,6 +956,18 @@ const drawUsaMap = (
         return defaultColor;
       })
       .on('end', function () {
+        // After animation ends, can set interaction listeners. If they go off in the
+        // middle of the animation it won't complete.
+        d3.select('button#tab_top_calls')
+          .on('click', topCallPerStateClicked)
+          .on('keydown', handleMapTabEvent);
+        d3.select('button#tab_total_calls')
+          .on('click', totalCallsPerStateClicked)
+          .on('keydown', handleMapTabEvent);
+        d3.select('button#tab_scaled_calls')
+          .on('click', scaledCallsPerStateClicked)
+          .on('keydown', handleMapTabEvent);
+
         if (initialState !== null) {
           selectState(initialState);
         }

--- a/react/src/utils/dashboardData.test.ts
+++ b/react/src/utils/dashboardData.test.ts
@@ -431,13 +431,12 @@ describe('getPopulation', () => {
 });
 
 describe('scaledCallsPerStateString', () => {
-  
   // 1. Test a standard, predictable calculation
-  // Population of WY is 588,753. 
+  // Population of WY is 588,753.
   // (58875.3 / 588753) * 100,000 = 10,000.0
   it('calculates and formats a standard state correctly', () => {
     const result = scaledCallsPerStateString(58875.3, 'WY', 100000);
-    expect(result).toBe("10000.0 calls per 100,000 people");
+    expect(result).toBe('10000.0 calls per 100,000 people');
   });
 
   // 2. Test rounding logic (0.05 should round up to 0.1)
@@ -455,20 +454,18 @@ describe('scaledCallsPerStateString', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const result = scaledCallsPerStateString(5, 'NOT_A_STATE', 1000);
     // (5 / 1) * 1000 = 5000.0
-    expect(result).toBe("5000.0 calls per 1,000 people");
+    expect(result).toBe('5000.0 calls per 1,000 people');
   });
 
   // 4. Test formatting of the denominator (thousands separator)
   it('formats the scaled population denominator with commas', () => {
     const result = scaledCallsPerStateString(10, 'AK', 1000000);
-    expect(result).toContain("1,000,000 people");
+    expect(result).toContain('1,000,000 people');
   });
 
   // 5. Test zero calls
   it('returns 0.0 for zero calls', () => {
     const result = scaledCallsPerStateString(0, 'TX', 100000);
-    expect(result).toBe("0.0 calls per 100,000 people");
+    expect(result).toBe('0.0 calls per 100,000 people');
   });
 });
-
-

--- a/react/src/utils/dashboardData.test.ts
+++ b/react/src/utils/dashboardData.test.ts
@@ -455,6 +455,7 @@ describe('scaledCallsPerStateString', () => {
     const result = scaledCallsPerStateString(5, 'NOT_A_STATE', 1000);
     // (5 / 1) * 1000 = 5000.0
     expect(result).toBe('5000.0 calls per 1,000 people');
+    warnSpy.mockRestore();
   });
 
   // 4. Test formatting of the denominator (thousands separator)

--- a/react/src/utils/dashboardData.test.ts
+++ b/react/src/utils/dashboardData.test.ts
@@ -2,7 +2,8 @@ import {
   getPopulation,
   getTopIssueData,
   getUsaMapKeyData,
-  processRepsData
+  processRepsData,
+  scaledCallsPerStateString
 } from './dashboardData';
 import { RepsSummaryData, RegionSummaryData, UsaSummaryData } from './api';
 import { Feature } from 'geojson';
@@ -428,3 +429,46 @@ describe('getPopulation', () => {
     warnSpy.mockRestore();
   });
 });
+
+describe('scaledCallsPerStateString', () => {
+  
+  // 1. Test a standard, predictable calculation
+  // Population of WY is 588,753. 
+  // (58875.3 / 588753) * 100,000 = 10,000.0
+  it('calculates and formats a standard state correctly', () => {
+    const result = scaledCallsPerStateString(58875.3, 'WY', 100000);
+    expect(result).toBe("10000.0 calls per 100,000 people");
+  });
+
+  // 2. Test rounding logic (0.05 should round up to 0.1)
+  it('rounds to exactly one decimal place', () => {
+    // California pop: 39,355,309
+    // Logic: (1000 / 39355309) * 100000 = 2.5409... -> rounds to 2.5
+    const result = scaledCallsPerStateString(1000, 'CA', 100000);
+    expect(result).toMatch(/^2.5 calls/);
+  });
+
+  // 3. Test the "Safe Getter" fallback
+  // When a state is missing, getPopulation returns 1.
+  it('handles missing states gracefully using the fallback population of 1', () => {
+    // Ignore console.warn output.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = scaledCallsPerStateString(5, 'NOT_A_STATE', 1000);
+    // (5 / 1) * 1000 = 5000.0
+    expect(result).toBe("5000.0 calls per 1,000 people");
+  });
+
+  // 4. Test formatting of the denominator (thousands separator)
+  it('formats the scaled population denominator with commas', () => {
+    const result = scaledCallsPerStateString(10, 'AK', 1000000);
+    expect(result).toContain("1,000,000 people");
+  });
+
+  // 5. Test zero calls
+  it('returns 0.0 for zero calls', () => {
+    const result = scaledCallsPerStateString(0, 'TX', 100000);
+    expect(result).toBe("0.0 calls per 100,000 people");
+  });
+});
+
+

--- a/react/src/utils/dashboardData.ts
+++ b/react/src/utils/dashboardData.ts
@@ -279,3 +279,17 @@ export function getPopulation(id: string): number {
   // We will usually divide by population. Make sure to return something!
   return 1;
 }
+
+// Converts the total number of calls into a string representing the calls
+// per population for the given `state`, rounded to one decimal place.
+export function scaledCallsPerStateString(
+  totalCalls: number,
+  state: string,
+  scaledPopDenominator: number
+): string {
+  const scaledCalls =
+    Math.round(
+      (totalCalls / getPopulation(state)) * scaledPopDenominator * 10
+    ) / 10;
+  return `${scaledCalls.toFixed(1)} calls per ${scaledPopDenominator.toLocaleString()} people`;
+};

--- a/react/src/utils/dashboardData.ts
+++ b/react/src/utils/dashboardData.ts
@@ -292,4 +292,4 @@ export function scaledCallsPerStateString(
       (totalCalls / getPopulation(state)) * scaledPopDenominator * 10
     ) / 10;
   return `${scaledCalls.toFixed(1)} calls per ${scaledPopDenominator.toLocaleString()} people`;
-};
+}


### PR DESCRIPTION
Round to one decimal rather than using a whole number, and allow key to be %5 instead of %10 (when the top calling state had 11 calls and the key went up to 20, we weren't making full use of the color scale).

Refactors scaled calls calculation and string method into a helper, add unit tests.

Also moves map tabs click listener into after initial map animation completes: if the user switched to scaled calls during animation, rendering wasn't correct.