### PR TITLE
[Dashboard] Ensure Maine is clickable on desktop

### DIFF
--- a/react/src/components/Dashboard.tsx
+++ b/react/src/components/Dashboard.tsx
@@ -110,7 +110,7 @@ const updateStateLabelPosition = (parent: SVGGraphicsElement) => {
   if (
     screenCoords.y + 24 > svgBb.height + svgOffsetY + svgBb.y ||
     screenCoords.y + 24 < svgBb.y + svgOffsetY ||
-    screenCoords.x > svgBb.width - labelWidth / 2 ||
+    screenCoords.x > svgBb.width - 24 ||
     screenCoords.x < -labelWidth / 2
   ) {
     label.attr('hidden', true);


### PR DESCRIPTION
Maine's label wasn't showing up on desktop on a 13" laptop. Makes hiding the label on the right less aggressive.