### PR TITLE
Address Hugo deprecation error preventing the app from building

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,5 +7,5 @@ title = "5 Calls"
 [params]
   description = "Spend 5 minutes. Make 5 calls. Make your voice heard."
 [permalinks]
-  done = "/issue/:filename/done/"
-  issue = "/issue/:filename/"
+  done = "/issue/:contentbasename/done/"
+  issue = "/issue/:contentbasename/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@ publish = "/final/"                                                       # we p
 command = "yarn build-js && yarn build-content && cd .. && hugo -b $DEPLOY_PRIME_URL/"
 [build.environment]
 # set hugo version for consistency
-HUGO_VERSION = '0.133.0'
+HUGO_VERSION = '0.160.1'
 # need yarn installed manually
 NETLIFY_USE_YARN = 'true'
 NODE_OPTIONS = '--unhandled-rejections=strict'


### PR DESCRIPTION
This fixes a deprecation error I received when running `hugo server` locally:

`ERROR deprecated: the ":filename" permalink token was deprecated in Hugo 0.144.0 and subsequently removed. Use ":contentbasename" instead.`