### PR TITLE
Use state-specific titles for state legislators

### DIFF
--- a/react/src/components/Script.test.tsx
+++ b/react/src/components/Script.test.tsx
@@ -303,7 +303,7 @@ describe('Script Component', () => {
         expect(result).toBe('Hello Governor Bob Johnson.');
       });
 
-      it('should handle StateLower area', () => {
+      it('should handle StateLower area with default Representative title', () => {
         const stateLowerContact = { ...mockContact, area: 'StateLower' };
         const script = 'Hello [REP/SEN NAME].';
         const result = scriptInstance!.scriptFormat(
@@ -312,7 +312,33 @@ describe('Script Component', () => {
           stateLowerContact
         );
 
-        expect(result).toBe('Hello Legislator John Smith.');
+        expect(result).toBe('Hello Representative John Smith.');
+      });
+
+      it('should use Delegate for StateLower in MD, VA, WV', () => {
+        const script = 'Hello [REP/SEN NAME].';
+        for (const state of ['MD', 'VA', 'WV']) {
+          const contact = { ...mockContact, area: 'StateLower', state };
+          const result = scriptInstance!.scriptFormat(
+            script,
+            mockLocationState,
+            contact
+          );
+          expect(result).toBe('Hello Delegate John Smith.');
+        }
+      });
+
+      it('should use Assembly Member for StateLower in CA, NY, NV', () => {
+        const script = 'Hello [REP/SEN NAME].';
+        for (const state of ['CA', 'NY', 'NV']) {
+          const contact = { ...mockContact, area: 'StateLower', state };
+          const result = scriptInstance!.scriptFormat(
+            script,
+            mockLocationState,
+            contact
+          );
+          expect(result).toBe('Hello Assembly Member John Smith.');
+        }
       });
 
       it('should handle StateUpper area', () => {
@@ -324,7 +350,7 @@ describe('Script Component', () => {
           stateUpperContact
         );
 
-        expect(result).toBe('Hello Legislator John Smith.');
+        expect(result).toBe('Hello Senator John Smith.');
       });
 
       it('should handle AttorneysGeneral area', () => {

--- a/react/src/components/Script.test.tsx
+++ b/react/src/components/Script.test.tsx
@@ -303,7 +303,7 @@ describe('Script Component', () => {
         expect(result).toBe('Hello Governor Bob Johnson.');
       });
 
-      it('should handle StateLower area with default Representative title', () => {
+      it('should handle StateLower area with default State Representative title', () => {
         const stateLowerContact = { ...mockContact, area: 'StateLower' };
         const script = 'Hello [REP/SEN NAME].';
         const result = scriptInstance!.scriptFormat(
@@ -312,7 +312,7 @@ describe('Script Component', () => {
           stateLowerContact
         );
 
-        expect(result).toBe('Hello Representative John Smith.');
+        expect(result).toBe('Hello State Representative John Smith.');
       });
 
       it('should use Delegate for StateLower in MD, VA, WV', () => {
@@ -350,7 +350,7 @@ describe('Script Component', () => {
           stateUpperContact
         );
 
-        expect(result).toBe('Hello Senator John Smith.');
+        expect(result).toBe('Hello State Senator John Smith.');
       });
 
       it('should handle AttorneysGeneral area', () => {

--- a/react/src/components/Script.tsx
+++ b/react/src/components/Script.tsx
@@ -19,6 +19,23 @@ interface State {
 const titleReg = /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]/gi;
 const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
 
+// MD/VA/WV use Delegate; CA/NY/NV use Assembly Member. Nebraska is unicameral
+// so its members all come through as StateUpper and pick up "Senator".
+const stateLowerTitle = (state: string): string => {
+  switch (state?.toUpperCase()) {
+    case 'CA':
+    case 'NY':
+    case 'NV':
+      return 'Assembly Member ';
+    case 'MD':
+    case 'VA':
+    case 'WV':
+      return 'Delegate ';
+    default:
+      return 'Representative ';
+  }
+};
+
 class Script extends React.Component<WithLocationProps, State> {
   state: State = { scriptMarkdown: '' };
   scriptRef = createRef<HTMLSpanElement>();
@@ -35,8 +52,10 @@ class Script extends React.Component<WithLocationProps, State> {
         title = 'Senator ';
         break;
       case 'StateLower':
+        title = stateLowerTitle(contact.state);
+        break;
       case 'StateUpper':
-        title = 'Legislator ';
+        title = 'Senator ';
         break;
       case 'Governor':
         title = 'Governor ';

--- a/react/src/components/Script.tsx
+++ b/react/src/components/Script.tsx
@@ -20,7 +20,7 @@ const titleReg = /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]/gi;
 const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
 
 // MD/VA/WV use Delegate; CA/NY/NV use Assembly Member. Nebraska is unicameral
-// so its members all come through as StateUpper and pick up "Senator".
+// so its members all come through as StateUpper and pick up "State Senator".
 const stateLowerTitle = (state: string): string => {
   switch (state?.toUpperCase()) {
     case 'CA':
@@ -32,7 +32,7 @@ const stateLowerTitle = (state: string): string => {
     case 'WV':
       return 'Delegate ';
     default:
-      return 'Representative ';
+      return 'State Representative ';
   }
 };
 
@@ -55,7 +55,7 @@ class Script extends React.Component<WithLocationProps, State> {
         title = stateLowerTitle(contact.state);
         break;
       case 'StateUpper':
-        title = 'Senator ';
+        title = 'State Senator ';
         break;
       case 'Governor':
         title = 'Governor ';


### PR DESCRIPTION
Closes #119. The StateLower/StateUpper branches in `getContactNameWithTitle` both fell through to 'Legislator', which was the source of the user confusion in the issue.

Switched StateUpper to 'Senator' (correct in every state, including Nebraska's unicameral chamber). StateLower defaults to 'Representative' and picks 'Delegate' for MD, VA, WV and 'Assembly Member' for CA, NY, NV.

I went a bit conservative on the exceptions list. NV and WI both have official forms that vary by source (NV bounces between 'Assemblymember' and 'Assemblyman'/'Assemblywoman'; WI uses 'Representative to the Assembly' formally but 'Representative' everywhere else), so I went with what reads most naturally in a phone-script context. Happy to widen the list if you want me to.

Test coverage is in Script.test.tsx, including a loop over each exception state.