### PR TITLE
support varied state lower chamber rep titles

### DIFF
--- a/react/src/common/constants.ts
+++ b/react/src/common/constants.ts
@@ -52,3 +52,9 @@ export const CUSTOM_EVENTS = {
   LOADED_REPS: 'loadedReps',
   SEARCH_RESULTS_RENDERED: 'searchResultsRendered'
 };
+
+export const STATES_WITH_DELEGATES = ['MD', 'VA', 'WV']
+
+// Note: Wisconsin has an Assembly but uses title "Representative"
+// NJ, NV, NY more commonly use Assemblywoman/Assemblyman but we don't have gender data
+export const STATES_WITH_ASSEMBLYMEMBERS = ['CA', 'NJ', 'NV', 'NY']

--- a/react/src/components/Script.test.tsx
+++ b/react/src/components/Script.test.tsx
@@ -60,6 +60,26 @@ describe('Script Component', () => {
     area: 'Governor'
   };
 
+  const mockStateDelegateContact: Contact = {
+    id: '4',
+    name: 'John Smith',
+    phone: '202-555-0100',
+    party: 'democrat',
+    state: 'MD',
+    reason: 'Test reason',
+    area: 'US House'
+  };
+
+  const mockStateAssemblymemberContact: Contact = {
+    id: '5',
+    name: 'John Smith',
+    phone: '202-555-0100',
+    party: 'democrat',
+    state: 'VA',
+    reason: 'Test reason',
+    area: 'US House'
+  };
+
   let scriptInstance: Script | null = null;
 
   const renderScriptComponent = (locationState?: LocationState) => {
@@ -312,7 +332,31 @@ describe('Script Component', () => {
           stateLowerContact
         );
 
-        expect(result).toBe('Hello Legislator John Smith.');
+        expect(result).toBe('Hello Rep. John Smith.');
+      });
+
+      it('should handle StateLower for State with Delegates', () => {
+        const stateLowerContact = { ...mockStateDelegateContact, area: 'StateLower' };
+        const script = 'Hello [REP/SEN NAME].';
+        const result = scriptInstance!.scriptFormat(
+          script,
+          mockLocationState,
+          stateLowerContact
+        );
+
+        expect(result).toBe('Hello Delegate John Smith.');
+      });
+
+      it('should handle StateLower for State with Assemblymembers', () => {
+        const stateLowerContact = { ...mockStateAssemblymemberContact, area: 'StateLower' };
+        const script = 'Hello [REP/SEN NAME].';
+        const result = scriptInstance!.scriptFormat(
+          script,
+          mockLocationState,
+          stateLowerContact
+        );
+
+        expect(result).toBe('Hello Assemblymember John Smith.');
       });
 
       it('should handle StateUpper area', () => {
@@ -324,7 +368,7 @@ describe('Script Component', () => {
           stateUpperContact
         );
 
-        expect(result).toBe('Hello Legislator John Smith.');
+        expect(result).toBe('Hello Senator John Smith.');
       });
 
       it('should handle AttorneysGeneral area', () => {

--- a/react/src/components/Script.tsx
+++ b/react/src/components/Script.tsx
@@ -54,8 +54,6 @@ class Script extends React.Component<WithLocationProps, State> {
       default:
         title = '';
     }
-    console.log('xxxcontact', contact)
-    console.log('xxxtitle', title)
     return title + contact.name;
   };
 

--- a/react/src/components/Script.tsx
+++ b/react/src/components/Script.tsx
@@ -35,8 +35,12 @@ class Script extends React.Component<WithLocationProps, State> {
         title = 'Senator ';
         break;
       case 'StateLower':
+        if (Constants.STATES_WITH_DELEGATES.includes(contact.state)) title = 'Delegate ';
+        else if (Constants.STATES_WITH_ASSEMBLYMEMBERS.includes(contact.state)) title = 'Assemblymember ';
+        else title = 'Rep. ';
+        break;
       case 'StateUpper':
-        title = 'Legislator ';
+        title = 'Senator ';
         break;
       case 'Governor':
         title = 'Governor ';
@@ -50,6 +54,8 @@ class Script extends React.Component<WithLocationProps, State> {
       default:
         title = '';
     }
+    console.log('xxxcontact', contact)
+    console.log('xxxtitle', title)
     return title + contact.name;
   };
 


### PR DESCRIPTION
Hi! Wanted to try out making a contribution here. 
For the following issue: https://github.com/5calls/5calls/issues/119

- Build a list of what each state calls upper/lower reps (Source: https://ballotpedia.org/Official_names_of_state_legislatures)
- Have the script customization use the right one

- Attempted to validate locally, but looks like most examples already have title provided by https://api.5calls.org/v1/issue/1144/script (which may have an existing bug, seeing "Rep." title listed for many State Senators)
